### PR TITLE
[nfcd] Add ability to keep presence checking after Acquiring tag. JB#51791

### DIFF
--- a/core/include/nfc_target.h
+++ b/core/include/nfc_target.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2018-2021 Jolla Ltd.
  * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020-2021 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -163,6 +164,20 @@ nfc_target_cancel_transmit(
     NfcTarget* target,
     guint id)
     NFCD_EXPORT;
+
+typedef enum nfc_sequence_flags {
+    NFC_SEQUENCE_FLAGS_NONE = 0x00,
+    NFC_SEQUENCE_FLAG_ALLOW_PRESENCE_CHECK = 0x01
+} NFC_SEQUENCE_FLAGS; /* Since 1.1.4 */
+
+NfcTargetSequence*
+nfc_target_sequence_new2(
+    NfcTarget* target,
+    NFC_SEQUENCE_FLAGS flags); /* Since 1.1.4 */
+
+NFC_SEQUENCE_FLAGS
+nfc_target_sequence_get_flags(
+    NfcTargetSequence* seq); /* Since 1.1.4 */
 
 G_END_DECLS
 

--- a/core/src/nfc_target_p.h
+++ b/core/src/nfc_target_p.h
@@ -98,6 +98,11 @@ nfc_target_sequence_unref(
     NfcTargetSequence* seq)
     NFCD_INTERNAL;
 
+void nfc_target_sequence_set_flags(
+    NfcTargetSequence* seq,
+    NFC_SEQUENCE_FLAGS flags)
+    NFCD_INTERNAL;
+
 #endif /* NFC_TARGET_PRIVATE_H */
 
 /*

--- a/plugins/dbus_service/org.sailfishos.nfc.Tag.xml
+++ b/plugins/dbus_service/org.sailfishos.nfc.Tag.xml
@@ -81,5 +81,10 @@
         <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       </arg>
     </method>
+    <!-- Interface version 5 -->
+    <method name="Acquire2">
+      <arg name="wait" type="b" direction="in"/>
+      <arg name="force_presence_check" type="b" direction="in"/>
+    </method>
   </interface>
 </node>


### PR DESCRIPTION
Flags field was added to target and Acquire2 method with `force
presence check` parameter. This allows not to skip tag presence checking
when tag was locked (Acquired).