### PR TITLE
API for allowing presence checks when tag is locked

### DIFF
--- a/core/include/nfc_target.h
+++ b/core/include/nfc_target.h
@@ -132,14 +132,30 @@ nfc_target_remove_handlers(
  * perform transmissions associated with this sequence.
  */
 
+typedef enum nfc_sequence_flags {
+    NFC_SEQUENCE_FLAGS_NONE = 0x00,
+    NFC_SEQUENCE_FLAG_ALLOW_PRESENCE_CHECK = 0x01
+} NFC_SEQUENCE_FLAGS; /* Since 1.1.4 */
+
 NfcTargetSequence*
 nfc_target_sequence_new(
     NfcTarget* target) /* Since 1.0.17 */
     NFCD_EXPORT;
 
+NfcTargetSequence*
+nfc_target_sequence_new2(
+    NfcTarget* target,
+    NFC_SEQUENCE_FLAGS flags) /* Since 1.1.4 */
+    NFCD_EXPORT;
+
 void
 nfc_target_sequence_free(
     NfcTargetSequence* seq) /* Since 1.0.17 */
+    NFCD_EXPORT;
+
+NFC_SEQUENCE_FLAGS
+nfc_target_sequence_flags(
+    NfcTargetSequence* seq) /* Since 1.1.4 */
     NFCD_EXPORT;
 
 /*

--- a/core/src/nfc_target.c
+++ b/core/src/nfc_target.c
@@ -91,6 +91,7 @@ struct nfc_target_sequence {
     NfcTargetSequence* next;
     gint refcount;
     NfcTarget* target;
+    NFC_SEQUENCE_FLAGS flags;
 };
 
 typedef struct nfc_target_sequence_queue {
@@ -527,6 +528,14 @@ NfcTargetSequence*
 nfc_target_sequence_new(
     NfcTarget* target)
 {
+    return nfc_target_sequence_new2(target, NFC_SEQUENCE_FLAGS_NONE);
+}
+
+NfcTargetSequence*
+nfc_target_sequence_new2(
+    NfcTarget* target,
+    NFC_SEQUENCE_FLAGS flags) /* Since 1.1.4 */
+{
     if (G_LIKELY(target)) {
         NfcTargetSequence* self = g_slice_new0(NfcTargetSequence);
         NfcTargetPriv* priv = target->priv;
@@ -534,6 +543,7 @@ nfc_target_sequence_new(
 
         g_atomic_int_set(&self->refcount, 1);
         self->target = target;
+        self->flags = flags;
 
         /* Insert it to the queue */
         if (queue->last) {
@@ -560,6 +570,13 @@ nfc_target_sequence_free(
     NfcTargetSequence* self)
 {
     nfc_target_sequence_unref(self);
+}
+
+NFC_SEQUENCE_FLAGS
+nfc_target_sequence_flags(
+    NfcTargetSequence* self) /* Since 1.1.4 */
+{
+    return G_LIKELY(self) ? self->flags : NFC_SEQUENCE_FLAGS_NONE;
 }
 
 /*==========================================================================*

--- a/plugins/dbus_service/org.sailfishos.nfc.Tag.xml
+++ b/plugins/dbus_service/org.sailfishos.nfc.Tag.xml
@@ -81,5 +81,10 @@
         <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       </arg>
     </method>
+    <!-- Interface version 5 -->
+    <method name="Acquire2"> <!-- Allows presense check -->
+      <arg name="wait" type="b" direction="in"/>
+   </method>
+   <method name="Release2"/> <!-- Matches Acquire2 -->
   </interface>
 </node>

--- a/unit/common/test_dbus.c
+++ b/unit/common/test_dbus.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020 Jolla Ltd.
- * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2021 Jolla Ltd.
+ * Copyright (C) 2019-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -183,17 +183,20 @@ test_dbus_free(
     TestDBus* self)
 {
     if (self) {
+        g_dbus_server_stop(self->server);
         if (self->start2_id) {
             g_source_remove(self->start2_id);
         }
         if (self->client_connection) {
+            g_dbus_connection_close_sync(self->client_connection, NULL, NULL);
             g_object_unref(self->client_connection);
         }
         if (self->server_connection) {
+            g_dbus_connection_close_sync(self->server_connection, NULL, NULL);
             g_object_unref(self->server_connection);
         }
         g_object_unref(self->observer);
-        g_dbus_server_stop(self->server);
+        g_object_unref(self->server);
         g_rmdir(self->tmpdir);
         g_free(self->tmpdir);
         g_free(self);

--- a/unit/core_target/test_core_target.c
+++ b/unit/core_target/test_core_target.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  * Copyright (C) 2020 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
@@ -388,6 +388,8 @@ test_null(
     nfc_target_gone(NULL);
     nfc_target_unref(NULL);
     g_assert(!nfc_target_sequence_new(NULL));
+    g_assert(!nfc_target_sequence_new2(NULL, NFC_SEQUENCE_FLAGS_NONE));
+    g_assert(!nfc_target_sequence_flags(NULL));
     nfc_target_sequence_free(NULL);
 }
 


### PR DESCRIPTION
Locks with and without presence checks are treated as separate locks. New D-Bus API `Acquire2`/`Release2` was added for manipulating new kind of locks.