### PR TITLE
Support for Bluetooth Simple Pairing

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -115,11 +115,14 @@ DBUS_NEARD_PLUGIN_SRC = \
   dbus_neard.c \
   dbus_neard_adapter.c \
   dbus_neard_error.c \
+  dbus_neard_manager.c \
   dbus_neard_plugin.c \
   dbus_neard_tag.c
 
 DBUS_NEARD_GEN_SRC = \
   org.neard.Adapter.c \
+  org.neard.HandoverAgent.c \
+  org.neard.Manager.c \
   org.neard.Record.c \
   org.neard.Tag.c
 

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -117,6 +117,7 @@ DBUS_NEARD_PLUGIN_SRC = \
   dbus_neard_error.c \
   dbus_neard_manager.c \
   dbus_neard_plugin.c \
+  dbus_neard_settings.c \
   dbus_neard_tag.c
 
 DBUS_NEARD_GEN_SRC = \
@@ -124,7 +125,8 @@ DBUS_NEARD_GEN_SRC = \
   org.neard.HandoverAgent.c \
   org.neard.Manager.c \
   org.neard.Record.c \
-  org.neard.Tag.c
+  org.neard.Tag.c \
+  org.sailfishos.neard.Settings.c
 
 DBUS_NEARD_SRC = \
   $(DBUS_NEARD_GEN_SRC) \

--- a/plugins/dbus_neard/dbus_neard.h
+++ b/plugins/dbus_neard/dbus_neard.h
@@ -47,6 +47,7 @@ typedef struct dbus_neard_adapter DBusNeardAdapter;
 typedef struct dbus_neard_tag DBusNeardTag;
 
 #define DBUS_NEARD_BUS_TYPE G_BUS_TYPE_SYSTEM
+#define DBUS_NEARD_DA_BUS   DA_BUS_SYSTEM
 
 #define DBUS_NEARD_ERROR (dbus_neard_error_quark())
 GQuark dbus_neard_error_quark(void);
@@ -58,6 +59,7 @@ typedef enum dbus_neard_error {
     DBUS_NEARD_ERROR_NOT_SUPPORTED,     /* org.neard.Error.NotSupported */
     DBUS_NEARD_ERROR_DOES_NOT_EXIST,    /* org.neard.Error.DoesNotExist */
     DBUS_NEARD_ERROR_ABORTED,           /* org.neard.Error.OperationAborted */
+    DBUS_NEARD_ERROR_ACCESS_DENIED,     /* org.neard.Error.AccessDenied */
     DBUS_NEARD_NUM_ERRORS
 } DBusNeardError;
 
@@ -71,6 +73,26 @@ typedef struct dbus_neard_protocol_name {
     NFC_PROTOCOL protocols;
     const char* name;
 } DBusNeardProtocolName;
+
+const DBusNeardProtocolName*
+dbus_neard_tag_type_name(
+    NFC_PROTOCOL protocol);
+
+/* DBusNeardSettings */
+
+typedef struct dbus_neard_settings {
+    gboolean bt_static_handover;
+} DBusNeardSettings;
+
+DBusNeardSettings*
+dbus_neard_settings_new(
+    void);
+
+void
+dbus_neard_settings_free(
+    DBusNeardSettings* settings);
+
+/* DBusNeardManager */
 
 DBusNeardManager*
 dbus_neard_manager_new(
@@ -89,9 +111,7 @@ dbus_neard_manager_handle_ndef(
     DBusNeardManager* manager,
     NfcNdefRec* ndef);
 
-const DBusNeardProtocolName*
-dbus_neard_tag_type_name(
-    NFC_PROTOCOL protocol);
+/* DBusNeardAdapter */
 
 DBusNeardAdapter*
 dbus_neard_adapter_new(
@@ -102,6 +122,8 @@ dbus_neard_adapter_new(
 void
 dbus_neard_adapter_free(
     DBusNeardAdapter* neard_adapter);
+
+/* DBusNeardTag */
 
 DBusNeardTag*
 dbus_neard_tag_new(

--- a/plugins/dbus_neard/dbus_neard.h
+++ b/plugins/dbus_neard/dbus_neard.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -42,8 +42,11 @@
 
 #include <gio/gio.h>
 
+typedef struct dbus_neard_manager DBusNeardManager;
 typedef struct dbus_neard_adapter DBusNeardAdapter;
 typedef struct dbus_neard_tag DBusNeardTag;
+
+#define DBUS_NEARD_BUS_TYPE G_BUS_TYPE_SYSTEM
 
 #define DBUS_NEARD_ERROR (dbus_neard_error_quark())
 GQuark dbus_neard_error_quark(void);
@@ -69,6 +72,23 @@ typedef struct dbus_neard_protocol_name {
     const char* name;
 } DBusNeardProtocolName;
 
+DBusNeardManager*
+dbus_neard_manager_new(
+    void);
+
+DBusNeardManager*
+dbus_neard_manager_ref(
+    DBusNeardManager* manager);
+
+void
+dbus_neard_manager_unref(
+    DBusNeardManager* manager);
+
+void
+dbus_neard_manager_handle_ndef(
+    DBusNeardManager* manager,
+    NfcNdefRec* ndef);
+
 const DBusNeardProtocolName*
 dbus_neard_tag_type_name(
     NFC_PROTOCOL protocol);
@@ -76,7 +96,8 @@ dbus_neard_tag_type_name(
 DBusNeardAdapter*
 dbus_neard_adapter_new(
     NfcAdapter* adapter,
-    GDBusObjectManagerServer* object_manager);
+    GDBusObjectManagerServer* object_manager,
+    DBusNeardManager* agent_manager);
 
 void
 dbus_neard_adapter_free(
@@ -86,7 +107,8 @@ DBusNeardTag*
 dbus_neard_tag_new(
     NfcTag* tag,
     const char* adapter_path,
-    GDBusObjectManagerServer* object_manager);
+    GDBusObjectManagerServer* object_manager,
+    DBusNeardManager* agent_manager);
 
 void
 dbus_neard_tag_free(

--- a/plugins/dbus_neard/dbus_neard_error.c
+++ b/plugins/dbus_neard/dbus_neard_error.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -40,7 +40,8 @@ static const GDBusErrorEntry dbus_neard_errors[] = {
     {DBUS_NEARD_ERROR_NOT_READY,      DBUS_NEARD_ERROR_("NotReady")},
     {DBUS_NEARD_ERROR_NOT_SUPPORTED,  DBUS_NEARD_ERROR_("NotSupported")},
     {DBUS_NEARD_ERROR_DOES_NOT_EXIST, DBUS_NEARD_ERROR_("DoesNotExist")},
-    {DBUS_NEARD_ERROR_ABORTED,        DBUS_NEARD_ERROR_("OperationAborted")}
+    {DBUS_NEARD_ERROR_ABORTED,        DBUS_NEARD_ERROR_("OperationAborted")},
+    {DBUS_NEARD_ERROR_ACCESS_DENIED,  DBUS_NEARD_ERROR_("AccessDenied")}
 };
 
 G_STATIC_ASSERT(G_N_ELEMENTS(dbus_neard_errors) == DBUS_NEARD_NUM_ERRORS);

--- a/plugins/dbus_neard/dbus_neard_manager.c
+++ b/plugins/dbus_neard/dbus_neard_manager.c
@@ -1,0 +1,463 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dbus_neard.h"
+#include "dbus_neard/org.neard.Manager.h"
+#include "dbus_neard/org.neard.HandoverAgent.h"
+
+#include <nfc_ndef.h>
+
+#include <gutil_misc.h>
+
+enum {
+    NEARD_CALL_REGISTER_HANDOVER_AGENT,
+    NEARD_CALL_UNREGISTER_HANDOVER_AGENT,
+    NEARD_CALL_COUNT
+};
+
+struct dbus_neard_manager {
+    int refcount;
+    OrgNeardManager* iface;
+    gulong neard_calls[NEARD_CALL_COUNT];
+    GHashTable* agents; /* carrier => DBusNeardHandoverAgent */
+};
+
+typedef struct dbus_neard_handover_agent {
+    DBusNeardManager* manager;
+    OrgNeardHandoverAgent* proxy;
+    char* peer;
+    char* path;
+    const char* carrier;
+    guint watch;
+} DBusNeardHandoverAgent;
+
+static const char NEARD_MANAGER_PATH[] = "/";
+static const char BLUETOOTH_CARRIER[] = "bluetooth";
+static const char WIFI_CARRIER[] = "wifi";
+
+static
+void
+dbus_neard_manager_drop_agent(
+    DBusNeardHandoverAgent* agent)
+{
+    if (agent->watch) {
+        g_bus_unwatch_name(agent->watch);
+        agent->watch = 0;
+    }
+    if (agent->proxy) {
+        g_object_unref(agent->proxy);
+        agent->proxy = NULL;
+    }
+}
+
+static
+void
+dbus_neard_manager_peer_vanished(
+    GDBusConnection* connection,
+    const char* name,
+    gpointer user_data)
+{
+    DBusNeardHandoverAgent* agent = user_data;
+    DBusNeardManager* manager = agent->manager;
+
+    GDEBUG("Handover agent %s is gone", name);
+    dbus_neard_manager_drop_agent(agent);
+    g_hash_table_remove(manager->agents, agent->carrier);
+}
+
+static
+DBusNeardHandoverAgent*
+dbus_neard_manager_new_agent(
+    DBusNeardManager* manager,
+    GDBusMethodInvocation* call,
+    const char* path,
+    const char* carrier,
+    GError** error)
+{
+    const char* sender = g_dbus_method_invocation_get_sender(call);
+    OrgNeardHandoverAgent* proxy =
+        org_neard_handover_agent_proxy_new_for_bus_sync(DBUS_NEARD_BUS_TYPE,
+            G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES, sender, path, NULL,
+            error);
+
+    if (proxy) {
+        DBusNeardHandoverAgent* agent = g_new0(DBusNeardHandoverAgent, 1);
+
+        GDEBUG("Registered %s handover agent %s at %s", carrier, path, sender);
+        agent->manager = manager;
+        agent->peer = g_strdup(sender);
+        agent->path = g_strdup(path);
+        agent->carrier = carrier; /* static pointer */
+        agent->proxy = proxy;
+        agent->watch = g_bus_watch_name(DBUS_NEARD_BUS_TYPE, sender,
+            G_BUS_NAME_WATCHER_FLAGS_NONE, NULL,
+            dbus_neard_manager_peer_vanished, agent, NULL);
+        return agent;
+    } else {
+        return NULL;
+    }
+}
+
+static
+void
+dbus_neard_manager_release_done(
+    GObject* proxy,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    GError* error = NULL;
+
+    if (org_neard_handover_agent_call_release_finish(
+        ORG_NEARD_HANDOVER_AGENT(proxy), result, &error)) {
+        GDEBUG("Release OK");
+    } else {
+        GERR("%s", GERRMSG(error));
+        g_error_free(error);
+    }
+}
+
+static
+void
+dbus_neard_manager_push_oob_done(
+    GObject* proxy,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    GError* error = NULL;
+
+    if (org_neard_handover_agent_call_push_oob_finish(
+        ORG_NEARD_HANDOVER_AGENT(proxy), result, &error)) {
+        GDEBUG("Handover OK");
+    } else {
+        GERR("%s", GERRMSG(error));
+        g_error_free(error);
+    }
+}
+
+static
+void
+dbus_neard_manager_free_agent(
+    void* user_data)
+{
+    DBusNeardHandoverAgent* agent = user_data;
+
+    if (agent->watch) g_bus_unwatch_name(agent->watch);
+    if (agent->proxy) {
+        /* D-Bus task will hold its own reference to the proxy */
+        org_neard_handover_agent_call_release(agent->proxy, NULL,
+            dbus_neard_manager_release_done, NULL);
+        g_object_unref(agent->proxy);
+    }
+    g_free(agent->peer);
+    g_free(agent->path);
+    g_free(agent);
+}
+
+static
+gboolean
+dbus_neard_manager_parse_Hs(
+    NfcNdefRec* ndef,
+    GUtilData* cdr)
+{
+    static const GUtilData type_Hs = { (const guint8*)"Hs", 2 };
+    static const GUtilData type_ac = { (const guint8*)"ac", 2 };
+
+    if ((ndef->flags & (NFC_NDEF_REC_FLAG_FIRST | NFC_NDEF_REC_FLAG_LAST)) ==
+        NFC_NDEF_REC_FLAG_FIRST && ndef->tnf == NFC_NDEF_TNF_WELL_KNOWN &&
+        gutil_data_equal(&ndef->type, &type_Hs) && ndef->payload.size > 1 &&
+        (ndef->payload.bytes[0] & 0xf0) == 0x10 /* MAJOR_VERSION */) {
+        /* The Handover Select Record, MAJOR_VERSION = 1 */
+        GUtilData ac;
+
+        /* Expecting "ac" record*/
+        ac.size = ndef->payload.size - 1;
+        ac.bytes = ndef->payload.bytes + 1;
+        if (ac.size > 6 &&
+            ac.bytes[0] == 0xd1 &&
+            ac.bytes[1] == type_ac.size &&
+            ac.size == 3 + type_ac.size + ac.bytes[2] &&
+            !memcmp(ac.bytes + 3, type_ac.bytes, type_ac.size)) {
+            /* Alternative Carrier Record inside Hs */
+            GUtilData ac_payload;
+
+            ac_payload.size = ac.bytes[2];
+            ac_payload.bytes = ac.bytes + (3 + type_ac.size);
+            if (ac_payload.size > 1 &&
+               (1 + ac_payload.bytes[1]) <= ac_payload.size) {
+                /* CARRIER_DATA_REFERENCE */
+                cdr->size = ac_payload.bytes[1];
+                cdr->bytes = ac_payload.bytes + 2;
+                return TRUE;
+            }
+        }
+    }
+    return FALSE;
+}
+
+static
+gboolean
+dbus_neard_manager_parse_bluetooth_oob(
+    NfcNdefRec* ndef,
+    const GUtilData* cdr,
+    GUtilData* eir)
+{
+    static const GUtilData type_bluetooth_oob = {
+        (const guint8*)"application/vnd.bluetooth.ep.oob", 32
+    };
+
+    if (ndef->tnf == NFC_NDEF_TNF_MEDIA_TYPE &&
+        gutil_data_equal(&ndef->type, &type_bluetooth_oob) &&
+        gutil_data_equal(&ndef->id, cdr) &&
+        ndef->payload.size >= 8) {
+        *eir = ndef->payload;
+        return ((eir->bytes[0] + (((guint)eir->bytes[1]) << 8)) == eir->size);
+    }
+    return FALSE;
+}
+
+static
+const char*
+dbus_neard_manager_valid_carrier(
+    const char* carrier)
+{
+    static const char* valid_carriers[] = { BLUETOOTH_CARRIER, WIFI_CARRIER };
+    gsize i;
+
+    for (i = 0; i < G_N_ELEMENTS(valid_carriers); i++) {
+        if (!g_strcmp0(carrier, valid_carriers[i])) {
+            return valid_carriers[i];
+        }
+    }
+    return NULL;
+}
+
+static
+void
+dbus_neard_manager_invalid_args(
+    GDBusMethodInvocation* call,
+    const char* message)
+{
+    g_dbus_method_invocation_return_error_literal(call, DBUS_NEARD_ERROR,
+        DBUS_NEARD_ERROR_INVALID_ARGS, message);
+}
+
+static
+void
+dbus_neard_manager_invalid_carrier(
+    GDBusMethodInvocation* call,
+    const char* carrier)
+{
+    GDEBUG("Invalid carrier '%s'", carrier);
+    g_dbus_method_invocation_return_error(call, DBUS_NEARD_ERROR,
+        DBUS_NEARD_ERROR_INVALID_ARGS, "Invalid carrier '%s'", carrier);
+}
+
+static
+gboolean
+dbus_neard_manager_register_handover_agent(
+    OrgNeardManager* iface,
+    GDBusMethodInvocation* call,
+    const char* path,
+    const char* carrier,
+    gpointer user_data)
+{
+    const char* valid_carrier = dbus_neard_manager_valid_carrier(carrier);
+
+    if (!valid_carrier) {
+        dbus_neard_manager_invalid_carrier(call, carrier);
+    } else {
+        GError* error = NULL;
+        DBusNeardManager* self = user_data;
+        DBusNeardHandoverAgent* agent = dbus_neard_manager_new_agent(self,
+            call, path, valid_carrier, &error);
+
+        if (agent) {
+            g_hash_table_replace(self->agents, (gpointer)valid_carrier, agent);
+            org_neard_manager_complete_register_handover_agent(iface, call);
+        } else {
+            g_dbus_method_invocation_return_gerror(call, error);
+            g_error_free(error);
+        }
+    }
+    return TRUE;
+}
+
+static
+gboolean
+dbus_neard_manager_unregister_handover_agent(
+    OrgNeardManager* iface,
+    GDBusMethodInvocation* call,
+    const char* path,
+    const char* carrier,
+    gpointer user_data)
+{
+    const char* valid_carrier = dbus_neard_manager_valid_carrier(carrier);
+
+    if (!valid_carrier) {
+        dbus_neard_manager_invalid_carrier(call, carrier);
+    } else {
+        DBusNeardManager* self = user_data;
+        DBusNeardHandoverAgent* agent = g_hash_table_lookup
+            (self->agents, valid_carrier);
+
+        if (agent) {
+            const char* sender = g_dbus_method_invocation_get_sender(call);
+
+            if (!g_strcmp0(sender, agent->peer)) {
+                GDEBUG("Unregistered %s handover agent %s at %s", carrier,
+                    path, sender);
+                dbus_neard_manager_drop_agent(agent);
+                g_hash_table_remove(self->agents, valid_carrier);
+                org_neard_manager_complete_unregister_handover_agent(iface,
+                    call);
+            } else {
+                dbus_neard_manager_invalid_args(call, "Invalid sender");
+            }
+        } else {
+            dbus_neard_manager_invalid_args(call, "No such agent");
+        }
+    }
+    return TRUE;
+}
+
+static
+void
+dbus_neard_manager_free(
+    DBusNeardManager* self)
+{
+    g_hash_table_destroy(self->agents);
+    gutil_disconnect_handlers(self->iface, self->neard_calls,
+        G_N_ELEMENTS(self->neard_calls));
+    g_object_unref(self->iface);
+    g_free(self);
+}
+
+DBusNeardManager*
+dbus_neard_manager_new(
+    void)
+{
+    GError* error = NULL;
+    DBusNeardManager* self = g_new0(DBusNeardManager, 1);
+    GDBusConnection* bus;
+
+    g_atomic_int_set(&self->refcount, 1);
+    self->agents = g_hash_table_new_full(g_str_hash, g_str_equal, NULL,
+        dbus_neard_manager_free_agent);
+    self->iface = org_neard_manager_skeleton_new();
+    self->neard_calls[NEARD_CALL_REGISTER_HANDOVER_AGENT] =
+        g_signal_connect(self->iface, "handle-register-handover-agent",
+            G_CALLBACK(dbus_neard_manager_register_handover_agent),
+            self);
+    self->neard_calls[NEARD_CALL_UNREGISTER_HANDOVER_AGENT] =
+        g_signal_connect(self->iface, "handle-unregister-handover-agent",
+            G_CALLBACK(dbus_neard_manager_unregister_handover_agent),
+            self);
+
+    bus = g_bus_get_sync(DBUS_NEARD_BUS_TYPE, NULL, &error);
+    if (bus && g_dbus_interface_skeleton_export(G_DBUS_INTERFACE_SKELETON
+        (self->iface), bus, NEARD_MANAGER_PATH, &error)) {
+        GDEBUG("Created Agent Manager object at %s", NEARD_MANAGER_PATH);
+    } else {
+        dbus_neard_manager_free(self);
+        self = NULL;
+    }
+    if (bus) g_object_unref(bus);
+    if (error) {
+        GERR("%s", GERRMSG(error));
+        g_error_free(error);
+    }
+    return self;
+}
+
+DBusNeardManager*
+dbus_neard_manager_ref(
+    DBusNeardManager* self)
+{
+    if (G_LIKELY(self)) {
+        g_atomic_int_inc(&self->refcount);
+    }
+    return self;
+}
+
+void
+dbus_neard_manager_unref(
+    DBusNeardManager* self)
+{
+    if (G_LIKELY(self)) {
+        if (g_atomic_int_dec_and_test(&self->refcount)) {
+            g_dbus_interface_skeleton_unexport(G_DBUS_INTERFACE_SKELETON
+                (self->iface));
+            dbus_neard_manager_free(self);
+        }
+    }
+}
+
+void
+dbus_neard_manager_handle_ndef(
+    DBusNeardManager* self,
+    NfcNdefRec* ndef)
+{
+    if (G_LIKELY(self)) {
+        DBusNeardHandoverAgent* agent = g_hash_table_lookup(self->agents,
+            BLUETOOTH_CARRIER);
+
+        if (agent) {
+            GUtilData cdr, eir;
+    
+            if (ndef && ndef->next &&
+                dbus_neard_manager_parse_Hs(ndef, &cdr) &&
+                dbus_neard_manager_parse_bluetooth_oob(ndef->next, &cdr, &eir)) {
+                GVariantBuilder builder;
+
+                g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+                g_variant_builder_add(&builder, "{sv}", "EIR",
+                    g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE,
+                        eir.bytes, eir.size, 1));
+
+                GDEBUG("Calling %s handover agent", agent->carrier);
+                org_neard_handover_agent_call_push_oob(agent->proxy,
+                    g_variant_builder_end(&builder), NULL,
+                    dbus_neard_manager_push_oob_done, NULL);
+            }
+        } else {
+            GDEBUG("No %s handover agent", BLUETOOTH_CARRIER);
+        }
+    }
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/plugins/dbus_neard/dbus_neard_settings.c
+++ b/plugins/dbus_neard/dbus_neard_settings.c
@@ -1,0 +1,418 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dbus_neard.h"
+#include "dbus_neard/org.sailfishos.neard.Settings.h"
+
+#ifdef HAVE_DBUSACCESS
+#include <dbusaccess_policy.h>
+#include <dbusaccess_peer.h>
+#endif
+
+#include <gutil_macros.h>
+#include <gutil_misc.h>
+
+#include <sys/stat.h>
+#include <errno.h>
+
+enum {
+    NEARD_SETTINGS_DBUS_CALL_GET_ALL,
+    NEARD_SETTINGS_DBUS_CALL_GET_INTERFACE_VERSION,
+    NEARD_SETTINGS_DBUS_CALL_GET_BT_STATIC_HANDOVER,
+    NEARD_SETTINGS_DBUS_CALL_SET_BT_STATIC_HANDOVER,
+    NEARD_SETTINGS_DBUS_CALL_COUNT
+};
+
+typedef struct dbus_neard_settings_priv {
+    DBusNeardSettings pub;
+    char* storage_dir;
+    char* storage_file;
+    GDBusConnection* bus;
+    OrgSailfishosNeardSettings* iface;
+    gulong dbus_call_id[NEARD_SETTINGS_DBUS_CALL_COUNT];
+#ifdef HAVE_DBUSACCESS
+    DAPolicy* policy;
+#endif
+} DBusNeardSettingsPriv;
+
+#define NEARD_SETTINGS_DBUS_PATH               "/"
+#define NEARD_SETTINGS_DBUS_INTERFACE_VERSION  (1)
+
+#define NEARD_SETTINGS_DIR                     "/var/lib/nfcd"
+#define NEARD_SETTINGS_FILE                    "neard"
+#define NEARD_SETTINGS_DIR_PERM                0700
+#define NEARD_SETTINGS_FILE_PERM               0600
+#define NEARD_SETTINGS_GROUP                   "Settings"
+#define NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER  "BluetoothStaticHandover"
+
+#ifdef HAVE_DBUSACCESS
+
+typedef enum dbus_neard_settings_action {
+    NEARD_SETTINGS_ACTION_GET_ALL = 1,
+    NEARD_SETTINGS_ACTION_GET_INTERFACE_VERSION,
+    NEARD_SETTINGS_ACTION_GET_BT_STATIC_HANDOVER,
+    NEARD_SETTINGS_ACTION_SET_BT_STATIC_HANDOVER,
+} NEARD_SETTINGS_ACTION;
+
+static const DA_ACTION dbus_neard_settings_policy_actions[] = {
+    { "GetAll", NEARD_SETTINGS_ACTION_GET_ALL, 0 },
+    { "GetInterfaceVersion", NEARD_SETTINGS_ACTION_GET_INTERFACE_VERSION, 0 },
+    { "GetBluetoothStaticHandover",
+       NEARD_SETTINGS_ACTION_GET_BT_STATIC_HANDOVER, 0 },
+    { "SetBluetoothStaticHandover",
+       NEARD_SETTINGS_ACTION_SET_BT_STATIC_HANDOVER, 0 },
+    { NULL }
+};
+
+#define NEARD_SETTINGS_DEFAULT_ACCESS_GET_ALL                 DA_ACCESS_ALLOW
+#define NEARD_SETTINGS_DEFAULT_ACCESS_GET_INTERFACE_VERSION   DA_ACCESS_ALLOW
+#define NEARD_SETTINGS_DEFAULT_ACCESS_GET_BT_STATIC_HANDOVER  DA_ACCESS_ALLOW
+#define NEARD_SETTINGS_DEFAULT_ACCESS_SET_BT_STATIC_HANDOVER  DA_ACCESS_DENY
+
+static const char dbus_neard_settings_default_policy[] =
+    DA_POLICY_VERSION ";group(privileged)=allow";
+
+/*
+ * Note: if settings_plugin_access_allowed() returns FALSE, it completes
+ * the call with error.
+ */
+static
+gboolean
+dbus_neard_settings_access_check(
+    DBusNeardSettingsPriv* self,
+    GDBusMethodInvocation* call,
+    NEARD_SETTINGS_ACTION action,
+    DA_ACCESS def)
+{
+    const char* sender = g_dbus_method_invocation_get_sender(call);
+    DAPeer* peer = da_peer_get(DBUS_NEARD_DA_BUS, sender);
+
+    /*
+     * If we get no peer information from dbus-daemon, it means that
+     * the peer is gone so it doesn't really matter what we do in this
+     * case - the reply will be dropped anyway.
+     */
+    if (peer && da_policy_check(self->policy, &peer->cred, action, 0, def) ==
+        DA_ACCESS_ALLOW) {
+        return TRUE;
+    }
+    g_dbus_method_invocation_return_error_literal(call, DBUS_NEARD_ERROR,
+        DBUS_NEARD_ERROR_ACCESS_DENIED, "D-Bus access denied");
+    return FALSE;
+}
+
+#define dbus_neard_settings_access_allowed(self,call,X) \
+    dbus_neard_settings_access_check(self, call, NEARD_SETTINGS_ACTION_##X, \
+        NEARD_SETTINGS_DEFAULT_ACCESS_##X)
+
+#else /* HAVE_DBUSACCESS */
+
+/* No access control (other than the one provided by dbus-daemon) */
+#define dbus_neard_settings_access_allowed(self,call,action) (TRUE)
+
+#endif /* HAVE_DBUSACCESS */
+
+static
+GKeyFile*
+dbus_neard_settings_load_config(
+    DBusNeardSettingsPriv* self)
+{
+    GKeyFile* config = g_key_file_new();
+
+    g_key_file_load_from_file(config, self->storage_file, 0, NULL);
+    return config;
+}
+
+static
+void
+dbus_neard_settings_save_config(
+    DBusNeardSettingsPriv* self,
+    GKeyFile* config)
+{
+    if (!g_mkdir_with_parents(self->storage_dir, NEARD_SETTINGS_DIR_PERM)) {
+        GError* error = NULL;
+        gsize len;
+        gchar* data = g_key_file_to_data(config, &len, NULL);
+
+        if (g_file_set_contents(self->storage_file, data, len, &error)) {
+            if (chmod(self->storage_file, NEARD_SETTINGS_FILE_PERM) < 0) {
+                GWARN("Failed to set %s permissions: %s", self->storage_file,
+                    strerror(errno));
+            } else {
+                GDEBUG("Wrote %s", self->storage_file);
+            }
+        } else {
+            GWARN("%s", GERRMSG(error));
+            g_error_free(error);
+        }
+        g_free(data);
+    } else {
+        GWARN("Failed to create directory %s", self->storage_dir);
+    }
+}
+
+static
+gboolean
+dbus_neard_settings_get_boolean(
+    GKeyFile* config,
+    const char* key,
+    gboolean defval)
+{
+    GError* error = NULL;
+    const gboolean val = g_key_file_get_boolean(config, NEARD_SETTINGS_GROUP,
+        key, &error);
+
+    if (error) {
+        g_error_free(error);
+        /* Default */
+        return defval;
+    } else {
+        return val;
+    }
+}
+
+static
+gboolean
+dbus_neard_settings_bt_static_handover(
+    GKeyFile* config)
+{
+    return dbus_neard_settings_get_boolean(config,
+        NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER, FALSE);
+}
+
+static
+void
+dbus_neard_settings_update_config(
+    DBusNeardSettingsPriv* self)
+{
+    DBusNeardSettings* pub = &self->pub;
+    GKeyFile* config = dbus_neard_settings_load_config(self);
+    gboolean bt_handover = dbus_neard_settings_bt_static_handover(config);
+    gboolean save = FALSE;
+
+    if (bt_handover != pub->bt_static_handover) {
+        save = TRUE;
+        g_key_file_set_boolean(config, NEARD_SETTINGS_GROUP,
+            NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER, pub->bt_static_handover);
+    }
+
+    if (save) {
+        dbus_neard_settings_save_config(self, config);
+    }
+
+    g_key_file_unref(config);
+}
+
+static
+void
+dbus_neard_settings_set_bt_static_handover(
+    DBusNeardSettingsPriv* self,
+    gboolean enabled)
+{
+    DBusNeardSettings* pub = &self->pub;
+
+    if (pub->bt_static_handover != enabled) {
+        pub->bt_static_handover = enabled;
+        GINFO("Bluetooth handover %s", enabled ? "enabled" : "disabled");
+        if (self->iface) {
+            org_sailfishos_neard_settings_emit_bluetooth_static_handover_changed
+                (self->iface, enabled);
+        }
+        dbus_neard_settings_update_config(self);
+    }
+}
+
+static
+gboolean
+dbus_neard_settings_handle_get_all(
+    OrgSailfishosNeardSettings* iface,
+    GDBusMethodInvocation* call,
+    DBusNeardSettingsPriv* self)
+{
+    if (dbus_neard_settings_access_allowed(self, call, GET_ALL)) {
+        org_sailfishos_neard_settings_complete_get_all(iface, call,
+            NEARD_SETTINGS_DBUS_INTERFACE_VERSION,
+            self->pub.bt_static_handover);
+    }
+    return TRUE;
+}
+
+static
+gboolean
+dbus_neard_settings_handle_get_interface_version(
+    OrgSailfishosNeardSettings* iface,
+    GDBusMethodInvocation* call,
+    DBusNeardSettingsPriv* self)
+{
+    if (dbus_neard_settings_access_allowed(self, call, GET_INTERFACE_VERSION)) {
+        org_sailfishos_neard_settings_complete_get_interface_version(iface,
+            call, NEARD_SETTINGS_DBUS_INTERFACE_VERSION);
+    }
+    return TRUE;
+}
+
+static
+gboolean
+dbus_neard_settings_handle_get_bt_static_handover(
+    OrgSailfishosNeardSettings* iface,
+    GDBusMethodInvocation* call,
+    DBusNeardSettingsPriv* self)
+{
+    if (dbus_neard_settings_access_allowed(self, call,
+        GET_BT_STATIC_HANDOVER)) {
+        org_sailfishos_neard_settings_complete_get_bluetooth_static_handover
+            (iface, call, self->pub.bt_static_handover);
+    }
+    return TRUE;
+}
+
+static
+gboolean
+dbus_neard_settings_handle_set_bt_static_handover(
+    OrgSailfishosNeardSettings* iface,
+    GDBusMethodInvocation* call,
+    gboolean enabled,
+    DBusNeardSettingsPriv* self)
+{
+    if (dbus_neard_settings_access_allowed(self, call,
+        SET_BT_STATIC_HANDOVER)) {
+        dbus_neard_settings_set_bt_static_handover(self, enabled);
+        org_sailfishos_neard_settings_complete_set_bluetooth_static_handover
+            (iface, call);
+    }
+    return TRUE;
+}
+
+static
+void
+dbus_neard_settings_unexport(
+    DBusNeardSettingsPriv* self)
+{
+    if (self->iface) {
+        g_dbus_interface_skeleton_unexport
+            (G_DBUS_INTERFACE_SKELETON(self->iface));
+        gutil_disconnect_handlers(self->iface, self->dbus_call_id,
+            G_N_ELEMENTS(self->dbus_call_id));
+        g_object_unref(self->iface);
+        self->iface = NULL;
+    }
+}
+
+DBusNeardSettings*
+dbus_neard_settings_new(
+    void)
+{
+    GError* error = NULL;
+    DBusNeardSettingsPriv* self = g_new0(DBusNeardSettingsPriv, 1);
+    DBusNeardSettings* pub = &self->pub;
+    GDBusConnection* bus = g_bus_get_sync(DBUS_NEARD_BUS_TYPE, NULL, &error);
+    GKeyFile* config;
+
+    self->storage_dir = g_strdup(NEARD_SETTINGS_DIR);
+    self->storage_file = g_build_filename(self->storage_dir,
+        NEARD_SETTINGS_FILE, NULL);
+
+    if (bus) {
+        OrgSailfishosNeardSettings* iface;
+
+        /* Attach D-Bus call handlers */
+        self->iface = iface = org_sailfishos_neard_settings_skeleton_new();
+        self->dbus_call_id[NEARD_SETTINGS_DBUS_CALL_GET_ALL] =
+            g_signal_connect(iface, "handle-get-all",
+                G_CALLBACK(dbus_neard_settings_handle_get_all), self);
+        self->dbus_call_id[NEARD_SETTINGS_DBUS_CALL_GET_INTERFACE_VERSION] =
+            g_signal_connect(iface, "handle-get-interface-version",
+                G_CALLBACK(dbus_neard_settings_handle_get_interface_version),
+                self);
+        self->dbus_call_id[NEARD_SETTINGS_DBUS_CALL_GET_BT_STATIC_HANDOVER] =
+            g_signal_connect(iface, "handle-get-bluetooth-static-handover",
+                G_CALLBACK(dbus_neard_settings_handle_get_bt_static_handover),
+                self);
+        self->dbus_call_id[NEARD_SETTINGS_DBUS_CALL_SET_BT_STATIC_HANDOVER] =
+            g_signal_connect(iface, "handle-set-bluetooth-static-handover",
+                G_CALLBACK(dbus_neard_settings_handle_set_bt_static_handover),
+                self);
+
+        /* Export the D-Bus object */
+        if (!g_dbus_interface_skeleton_export(G_DBUS_INTERFACE_SKELETON(iface),
+            bus, NEARD_SETTINGS_DBUS_PATH, &error)) {
+            dbus_neard_settings_unexport(self);
+            g_object_unref(self->bus);
+            self->bus = NULL;
+        }
+    }
+
+    if (error) {
+        GERR("%s", GERRMSG(error));
+        g_error_free(error);
+    }
+
+#ifdef HAVE_DBUSACCESS
+    self->policy = da_policy_new_full(dbus_neard_settings_default_policy,
+        dbus_neard_settings_policy_actions);
+#endif
+
+    /* Load current value(s) from the config file */
+    config = dbus_neard_settings_load_config(self);
+    pub->bt_static_handover = dbus_neard_settings_bt_static_handover(config);
+    g_key_file_unref(config);
+
+    return pub;
+}
+
+void
+dbus_neard_settings_free(
+    DBusNeardSettings* pub)
+{
+    if (pub) {
+        DBusNeardSettingsPriv* self = G_CAST(pub, DBusNeardSettingsPriv, pub);
+
+        dbus_neard_settings_unexport(self);
+#ifdef HAVE_DBUSACCESS
+        da_policy_unref(self->policy);
+#endif
+        if (self->bus) {
+            g_object_unref(self->bus);
+        }
+        g_free(self->storage_dir);
+        g_free(self->storage_file);
+        g_free(self);
+    }
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/plugins/dbus_neard/org.neard.HandoverAgent.xml
+++ b/plugins/dbus_neard/org.neard.HandoverAgent.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.neard.HandoverAgent">
+        <method name="PushOOB">
+            <arg name="value" type="a{sv}" direction="in"/>
+        </method>
+        <method name="Release"/>
+    </interface>
+</node>

--- a/plugins/dbus_neard/org.neard.Manager.xml
+++ b/plugins/dbus_neard/org.neard.Manager.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.neard.Manager">
+        <method name="RegisterHandoverAgent">
+            <arg name="path" type="o" direction="in"/>
+            <arg name="carrier" type="s" direction="in"/>
+        </method>
+        <method name="UnregisterHandoverAgent">
+            <arg name="path" type="o" direction="in"/>
+            <arg name="carrier" type="s" direction="in"/>
+        </method>
+    </interface>
+</node>

--- a/plugins/dbus_neard/org.neard.Manager.xml
+++ b/plugins/dbus_neard/org.neard.Manager.xml
@@ -10,5 +10,10 @@
             <arg name="path" type="o" direction="in"/>
             <arg name="carrier" type="s" direction="in"/>
         </method>
+        <!-- Signals (Sailfish OS extension) -->
+        <signal name="StaticHandoverCompleted">
+            <arg name="carrier" type="s"/>
+            <arg name="success" type="b"/>
+        </signal>
     </interface>
 </node>

--- a/plugins/dbus_neard/org.neard.conf
+++ b/plugins/dbus_neard/org.neard.conf
@@ -11,6 +11,7 @@
         <allow send_destination="org.neard" send_interface="org.freedesktop.DBus.Introspectable"/>
         <allow send_destination="org.neard" send_interface="org.freedesktop.DBus.Properties"/>
         <allow send_destination="org.neard" send_interface="org.freedesktop.DBus.ObjectManager"/>
+        <allow send_destination="org.neard" send_interface="org.sailfishos.neard.Settings"/>
         <allow send_destination="org.neard" send_interface="org.neard.Manager"/>
         <allow send_destination="org.neard" send_interface="org.neard.Adapter"/>
         <allow send_destination="org.neard" send_interface="org.neard.Record"/>

--- a/plugins/dbus_neard/org.neard.conf
+++ b/plugins/dbus_neard/org.neard.conf
@@ -11,6 +11,7 @@
         <allow send_destination="org.neard" send_interface="org.freedesktop.DBus.Introspectable"/>
         <allow send_destination="org.neard" send_interface="org.freedesktop.DBus.Properties"/>
         <allow send_destination="org.neard" send_interface="org.freedesktop.DBus.ObjectManager"/>
+        <allow send_destination="org.neard" send_interface="org.neard.Manager"/>
         <allow send_destination="org.neard" send_interface="org.neard.Adapter"/>
         <allow send_destination="org.neard" send_interface="org.neard.Record"/>
         <allow send_destination="org.neard" send_interface="org.neard.Tag"/>

--- a/plugins/dbus_neard/org.sailfishos.neard.Settings.xml
+++ b/plugins/dbus_neard/org.sailfishos.neard.Settings.xml
@@ -1,0 +1,23 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.sailfishos.neard.Settings">
+        <method name="GetAll">
+            <arg name="version" type="i" direction="out"/>
+            <arg name="bluetooth_static_handover" type="b" direction="out"/>
+        </method>
+        <method name="GetInterfaceVersion">
+            <arg name="version" type="i" direction="out"/>
+        </method>
+        <method name="GetBluetoothStaticHandover">
+            <arg name="enabled" type="b" direction="out"/>
+        </method>
+        <method name="SetBluetoothStaticHandover">
+            <arg name="enabled" type="b" direction="in"/>
+        </method>
+        <!-- Signals -->
+        <signal name="BluetoothStaticHandoverChanged">
+            <arg name="enabled" type="b"/>
+        </signal>
+    </interface>
+</node>


### PR DESCRIPTION
This (partially) implements `org.neard.Manager` D-Bus interfaces and parsing of BTSSP NDEF records. EIR is then passed to bluetoothd. To actually work, requires NFC support to be enabled in bluetoothd (by default it's off).