### PR TITLE
Configure plugins over D-Bus

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -31,6 +31,7 @@ LIB = $(LIB_NAME).a
 SRC = \
   nfc_adapter.c \
   nfc_crc.c \
+  nfc_config.c \
   nfc_core.c \
   nfc_initiator.c \
   nfc_llc.c \

--- a/core/include/nfc_config.h
+++ b/core/include/nfc_config.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2022 Jolla Ltd.
+ * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NFC_CONFIG_H
+#define NFC_CONFIG_H
+
+#include "nfc_types.h"
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/* This API exists since 1.1.10 */
+
+/*
+ * NFC_CONFIGURABLE interface is supposed be implemented by NfcPlugins
+ * to expose their configurable options to nfcd core.
+ *
+ * GVariants returned by NfcConfigurable::get_value() could be either
+ * floating or non-floating refs. nfc_config_get_value() passes those
+ * through g_variant_take_ref() to convert them to full references and
+ * always returns a full reference (or NULL). However, if you call
+ * NfcConfigurable::get_value() directly, you have to do that dance
+ * yourself.
+ *
+ * Similarly, nfc_config_set_value() handles floating GVariants, but
+ * NfcConfigurable::set_value() shouldn't be expected to do the same
+ * thing, if called directly.
+ *
+ * NULL value passed to NfcConfigurable::set_value() must be interpreted
+ * as the default value.
+ */
+
+GType nfc_configurable_get_type(void);
+#define NFC_TYPE_CONFIGURABLE (nfc_configurable_get_type())
+#define NFC_CONFIGURABLE(obj) G_TYPE_CHECK_INSTANCE_CAST(obj, \
+        NFC_TYPE_CONFIGURABLE, NfcConfigurable)
+#define NFC_IS_CONFIGURABLE(obj) G_TYPE_CHECK_INSTANCE_TYPE(obj, \
+        NFC_TYPE_CONFIGURABLE)
+#define NFC_CONFIGURABLE_GET_IFACE(obj) G_TYPE_INSTANCE_GET_INTERFACE(obj, \
+        NFC_TYPE_CONFIGURABLE, NfcConfigurableInterface)
+
+typedef struct nfc_configurable_interface NfcConfigurableInterface;
+
+typedef
+void
+(*NfcConfigChangeFunc)(
+    NfcConfigurable* config,
+    const char* key,
+    GVariant* value,
+    void* user_data);
+
+struct nfc_configurable_interface {
+    GTypeInterface parent;
+
+    const char* const* (*get_keys)(NfcConfigurable* conf);
+    GVariant* (*get_value)(NfcConfigurable* config, const char* key);
+    gboolean (*set_value)(NfcConfigurable* config, const char* key,
+        GVariant* value);
+    gulong (*add_change_handler)(NfcConfigurable* config, const char* key,
+        NfcConfigChangeFunc func, void* user_data);
+    void (*remove_handler)(NfcConfigurable* config, gulong id);
+
+    /* Padding for future expansion */
+    void (*_reserved1)(void);
+    void (*_reserved2)(void);
+    void (*_reserved3)(void);
+    void (*_reserved4)(void);
+    void (*_reserved5)(void);
+};
+
+const char* const*
+nfc_config_get_keys(
+    NfcConfigurable* conf);
+
+GVariant*
+nfc_config_get_value(
+    NfcConfigurable* config,
+    const char* key);
+
+gboolean
+nfc_config_set_value(
+    NfcConfigurable* config,
+    const char* key,
+    GVariant* value);
+
+gulong
+nfc_config_add_change_handler(
+    NfcConfigurable* config,
+    const char* key,
+    NfcConfigChangeFunc func,
+    void* user_data);
+
+void
+nfc_config_remove_handler(
+    NfcConfigurable* config,
+    gulong id);
+
+G_END_DECLS
+
+#endif /* NFC_CONFIG_H */
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/core/include/nfc_plugin_impl.h
+++ b/core/include/nfc_plugin_impl.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -46,13 +46,18 @@ typedef struct nfc_plugin_class {
     gboolean (*start)(NfcPlugin* plugin, NfcManager* manager);
     void (*stop)(NfcPlugin* plugin);
 
+    /* Since 1.1.10 */
+    void (*started)(NfcPlugin* plugin); /* All plugins started */
+
     /* Padding for future expansion */
     void (*_reserved1)(void);
     void (*_reserved2)(void);
     void (*_reserved3)(void);
     void (*_reserved4)(void);
-    void (*_reserved5)(void);
 } NfcPluginClass;
+
+#define NFC_PLUGIN_CLASS(klass) G_TYPE_CHECK_CLASS_CAST(klass, \
+        NFC_TYPE_PLUGIN, NfcPluginClass) /* Since 1.1.10 */
 
 /*
  * NFC_PLUGIN_DEFINE - simple way to define NfcPluginDesc with a single

--- a/core/include/nfc_types.h
+++ b/core/include/nfc_types.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  * Copyright (C) 2020 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
@@ -41,6 +41,7 @@ G_BEGIN_DECLS
 /* Types */
 
 typedef struct nfc_adapter NfcAdapter;
+typedef struct nfc_configurable NfcConfigurable;        /* Since 1.1.10 */
 typedef struct nfc_initiator NfcInitiator;              /* Since 1.1.0 */
 typedef struct nfc_language NfcLanguage;                /* Since 1.0.15 */
 typedef struct nfc_peer_connection NfcPeerConnection;   /* Since 1.1.0 */

--- a/core/src/nfc_config.c
+++ b/core/src/nfc_config.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2022 Jolla Ltd.
+ * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nfc_config.h"
+
+G_DEFINE_INTERFACE(NfcConfigurable, nfc_configurable, G_TYPE_OBJECT)
+
+/*==========================================================================*
+ * Interface
+ *==========================================================================*/
+
+const char* const*
+nfc_config_get_keys(
+    NfcConfigurable* self)
+{
+    return G_LIKELY(self) ?
+        NFC_CONFIGURABLE_GET_IFACE(self)->get_keys(self) :
+        NULL;
+}
+
+GVariant*
+nfc_config_get_value(
+    NfcConfigurable* self,
+    const char* key)
+{
+    if (G_LIKELY(self) && G_LIKELY(key)) {
+        GVariant* val = NFC_CONFIGURABLE_GET_IFACE(self)->get_value(self, key);
+
+        if (val) {
+            /* Make sure we return a full reference */
+            return g_variant_take_ref(val);
+        }
+    }
+    return NULL;
+}
+
+gboolean
+nfc_config_set_value(
+    NfcConfigurable* self,
+    const char* key,
+    GVariant* value)
+{
+    if (G_LIKELY(self) && G_LIKELY(key)) {
+        gboolean ok;
+
+        /* Sink weird floating references before calling set_value() */
+        if (value) g_variant_ref_sink(value);
+        ok = NFC_CONFIGURABLE_GET_IFACE(self)->set_value(self, key, value);
+        if (value) g_variant_unref(value);
+        return ok;
+    } else {
+        return FALSE;
+    }
+}
+
+gulong
+nfc_config_add_change_handler(
+    NfcConfigurable* self,
+    const char* key,
+    NfcConfigChangeFunc func,
+    void* user_data)
+{
+    return (G_LIKELY(self) && G_LIKELY(func)) ?
+        NFC_CONFIGURABLE_GET_IFACE(self)->add_change_handler(self, key,
+        func, user_data) : 0;
+}
+
+void
+nfc_config_remove_handler(
+    NfcConfigurable* self,
+    gulong id)
+{
+    if (G_LIKELY(self) && G_LIKELY(id)) {
+        NFC_CONFIGURABLE_GET_IFACE(self)->remove_handler(self, id);
+    }
+}
+
+/*==========================================================================*
+ * Internals
+ *==========================================================================*/
+
+static
+const char* const*
+nfc_configurable_default_get_keys(
+    NfcConfigurable* self)
+{
+    static const char* none[] = { NULL };
+
+    return none;
+}
+
+static
+GVariant*
+nfc_configurable_default_get_value(
+    NfcConfigurable* self,
+    const char* key)
+{
+    return NULL;
+}
+
+static
+gboolean
+nfc_configurable_default_set_value(
+    NfcConfigurable* self,
+    const char* key,
+    GVariant* value)
+{
+    return FALSE;
+}
+
+static
+gulong
+nfc_configurable_default_add_change_handler(
+    NfcConfigurable* self,
+    const char* key,
+    NfcConfigChangeFunc func,
+    void* user_data)
+{
+    return 0;
+}
+
+static
+void
+nfc_configurable_default_remove_handler(
+    NfcConfigurable* self,
+    gulong id)
+{
+    g_signal_handler_disconnect(self, id);
+}
+
+static
+void
+nfc_configurable_default_init(
+    NfcConfigurableInterface* iface)
+{
+    iface->get_keys = nfc_configurable_default_get_keys;
+    iface->get_value = nfc_configurable_default_get_value;
+    iface->set_value = nfc_configurable_default_set_value;
+    iface->add_change_handler = nfc_configurable_default_add_change_handler;
+    iface->remove_handler = nfc_configurable_default_remove_handler;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/core/src/nfc_plugin.c
+++ b/core/src/nfc_plugin.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -76,35 +76,42 @@ nfc_plugin_start(
     NfcPlugin* self,
     NfcManager* manager)
 {
-    if (G_LIKELY(self)) {
-        NfcPluginPriv* priv = self->priv;
+    /* Caller checks plugin pointer for NULL */
+    NfcPluginPriv* priv = self->priv;
 
-        /* Don't start twice */
-        if (priv->started) {
-            /* Already started */
-            return TRUE;
-        } else if (NFC_PLUGIN_GET_CLASS(self)->start(self, manager)) {
-            /* Started successfully */
-            priv->started = TRUE;
-            return TRUE;
-        }
+    /* Don't start twice */
+    if (priv->started) {
+        /* Already started */
+        return TRUE;
+    } else if (NFC_PLUGIN_GET_CLASS(self)->start(self, manager)) {
+        /* Started successfully */
+        priv->started = TRUE;
+        return TRUE;
+    } else {
+        return FALSE;
     }
-    return FALSE;
 }
 
 void
 nfc_plugin_stop(
     NfcPlugin* self)
 {
-    if (G_LIKELY(self)) {
-        NfcPluginPriv* priv = self->priv;
+    /* Caller checks plugin pointer for NULL */
+    NfcPluginPriv* priv = self->priv;
 
-        /* Only stop if started */
-        if (priv->started) {
-            NFC_PLUGIN_GET_CLASS(self)->stop(self);
-            priv->started = FALSE;
-        }
+    /* Only stop if started */
+    if (priv->started) {
+        NFC_PLUGIN_GET_CLASS(self)->stop(self);
+        priv->started = FALSE;
     }
+}
+
+void
+nfc_plugin_started(
+    NfcPlugin* self)
+{
+    /* Caller checks plugin pointer for NULL */
+    NFC_PLUGIN_GET_CLASS(self)->started(self);
 }
 
 /*==========================================================================*
@@ -122,7 +129,7 @@ nfc_plugin_default_start(
 
 static
 void
-nfc_plugin_default_stop(
+nfc_plugin_default_nop(
     NfcPlugin* self)
 {
 }
@@ -157,7 +164,8 @@ nfc_plugin_class_init(
     g_type_class_add_private(klass, sizeof(NfcPluginPriv));
     object_class->dispose = nfc_plugin_dispose;
     klass->start = nfc_plugin_default_start;
-    klass->stop = nfc_plugin_default_stop;
+    klass->stop = nfc_plugin_default_nop;
+    klass->started = nfc_plugin_default_nop;
 }
 
 /*

--- a/core/src/nfc_plugin_p.h
+++ b/core/src/nfc_plugin_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -45,6 +45,11 @@ nfc_plugin_start(
 
 void
 nfc_plugin_stop(
+    NfcPlugin* plugin)
+    NFCD_INTERNAL;
+
+void
+nfc_plugin_started(
     NfcPlugin* plugin)
     NFCD_INTERNAL;
 

--- a/core/src/nfc_plugins.c
+++ b/core/src/nfc_plugins.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -379,7 +379,7 @@ nfc_plugins_start(
                 }
 
                 gutil_log(GLOG_MODULE_CURRENT,
-                    (desc->flags & NFC_PLUGIN_FLAG_MUST_START) ? 
+                    (desc->flags & NFC_PLUGIN_FLAG_MUST_START) ?
                     GLOG_LEVEL_ERR : GLOG_LEVEL_WARN,
                    "Plugin \"%s\" failed to start", desc->name);
 
@@ -388,7 +388,16 @@ nfc_plugins_start(
             }
             l = next;
         }
-        return ok;
+
+        if (ok) {
+            /* Notify plugins of a successful start */
+            for (l = self->plugins; l; l = l->next) {
+                NfcPluginData* data = l->data;
+
+                nfc_plugin_started(data->plugin);
+            }
+            return TRUE;
+        }
     }
     return FALSE;
 }

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -169,6 +169,7 @@ $(COVERAGE_DBUS_NEARD_BUILD_DIR):
 
 SETTINGS_DIR = settings
 SETTINGS_PLUGIN_SRC = \
+  settings_dbus_name.c \
   settings_plugin.c
 
 SETTINGS_GEN_SRC = \

--- a/plugins/dbus_neard/dbus_neard.h
+++ b/plugins/dbus_neard/dbus_neard.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -42,8 +42,9 @@
 
 #include <gio/gio.h>
 
-typedef struct dbus_neard_manager DBusNeardManager;
 typedef struct dbus_neard_adapter DBusNeardAdapter;
+typedef struct dbus_neard_manager DBusNeardManager;
+typedef struct dbus_neard_settings DBusNeardSettings;
 typedef struct dbus_neard_tag DBusNeardTag;
 
 #define DBUS_NEARD_BUS_TYPE G_BUS_TYPE_SYSTEM
@@ -63,11 +64,17 @@ typedef enum dbus_neard_error {
     DBUS_NEARD_NUM_ERRORS
 } DBusNeardError;
 
-/* neard D-Bus interface is mixing different things in a weird way... */
 #define NEARD_PROTOCOL_FELICA  "Felica"
 #define NEARD_PROTOCOL_MIFARE  "MIFARE"
 #define NEARD_PROTOCOL_ISO_DEP "ISO-DEP"
 #define NEARD_PROTOCOL_NFC_DEP "NFC-DEP"
+
+#define NEARD_SETTINGS_DEFAULT_BT_STATIC_HANDOVER FALSE
+#define NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER "BluetoothStaticHandover"
+
+typedef struct dbus_neard_options {
+    gboolean bt_static_handover;
+} DBusNeardOptions;
 
 typedef struct dbus_neard_protocol_name {
     NFC_PROTOCOL protocols;
@@ -80,13 +87,9 @@ dbus_neard_tag_type_name(
 
 /* DBusNeardSettings */
 
-typedef struct dbus_neard_settings {
-    gboolean bt_static_handover;
-} DBusNeardSettings;
-
 DBusNeardSettings*
 dbus_neard_settings_new(
-    void);
+    NfcConfigurable* config);
 
 void
 dbus_neard_settings_free(
@@ -96,7 +99,7 @@ dbus_neard_settings_free(
 
 DBusNeardManager*
 dbus_neard_manager_new(
-    void);
+    const DBusNeardOptions* options);
 
 DBusNeardManager*
 dbus_neard_manager_ref(

--- a/plugins/dbus_neard/dbus_neard_plugin.c
+++ b/plugins/dbus_neard/dbus_neard_plugin.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -36,10 +36,15 @@
 #include <nfc_adapter.h>
 #include <nfc_manager.h>
 #include <nfc_plugin_impl.h>
+#include <nfc_config.h>
 
 #include <gutil_misc.h>
 
+#include <glib/gstdio.h>
+
 GLOG_MODULE_DEFINE("dbus-neard");
+
+#define NEARD_SERVICE "org.neard"
 
 enum {
     MANAGER_ADAPTER_ADDED,
@@ -56,14 +61,36 @@ typedef struct dbus_neard_plugin {
     NfcManager* manager;
     gulong event_id[MANAGER_EVENT_COUNT];
     DBusNeardManager* agent_manager;
+    DBusNeardSettings* settings;
+    DBusNeardOptions options;
 } DBusNeardPlugin;
 
-G_DEFINE_TYPE(DBusNeardPlugin, dbus_neard_plugin, NFC_TYPE_PLUGIN)
-#define DBUS_NEARD_TYPE_PLUGIN (dbus_neard_plugin_get_type())
-#define DBUS_NEARD_PLUGIN(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), \
-        DBUS_NEARD_TYPE_PLUGIN, DBusNeardPlugin))
+static
+void
+dbus_neard_plugin_config_init(
+    NfcConfigurableInterface* iface);
 
-#define NEARD_SERVICE "org.neard"
+GType dbus_neard_plugin_get_type() G_GNUC_INTERNAL;
+G_DEFINE_TYPE_WITH_CODE(DBusNeardPlugin, dbus_neard_plugin, NFC_TYPE_PLUGIN,
+G_IMPLEMENT_INTERFACE(NFC_TYPE_CONFIGURABLE, dbus_neard_plugin_config_init))
+#define THIS_TYPE dbus_neard_plugin_get_type()
+#define THIS(obj) G_TYPE_CHECK_INSTANCE_CAST((obj), THIS_TYPE, DBusNeardPlugin)
+
+enum neard_plugin_signal {
+     SIGNAL_CONFIG_VALUE_CHANGED,
+     SIGNAL_COUNT
+};
+
+#define SIGNAL_CONFIG_VALUE_CHANGED_NAME "neard-plugin-config-value-changed"
+
+static guint dbus_neard_plugin_signals[SIGNAL_COUNT] = { 0 };
+
+/*
+ * Originally, neard settings were stored in this file. Now it's only
+ * used for migration purposes.
+ */
+#define NEARD_SETTINGS_FILE     "/var/lib/nfcd/neard"
+#define NEARD_SETTINGS_GROUP    "Settings"
 
 static
 void
@@ -91,7 +118,7 @@ dbus_neard_adapter_added(
     NfcAdapter* adapter,
     void* plugin)
 {
-    dbus_neard_plugin_create_adapter(DBUS_NEARD_PLUGIN(plugin), adapter);
+    dbus_neard_plugin_create_adapter(THIS(plugin), adapter);
 }
 
 static
@@ -101,7 +128,7 @@ dbus_neard_adapter_removed(
     NfcAdapter* adapter,
     void* plugin)
 {
-    DBusNeardPlugin* self = DBUS_NEARD_PLUGIN(plugin);
+    DBusNeardPlugin* self = THIS(plugin);
 
     g_hash_table_remove(self->adapters, (void*)adapter->name);
 }
@@ -113,7 +140,7 @@ dbus_neard_plugin_name_acquired(
     const gchar* name,
     gpointer plugin)
 {
-    DBusNeardPlugin* self = DBUS_NEARD_PLUGIN(plugin);
+    DBusNeardPlugin* self = THIS(plugin);
 
     GDEBUG("Acquired service name '%s'", name);
     g_dbus_object_manager_server_set_connection(self->object_manager, bus);
@@ -126,7 +153,7 @@ dbus_neard_plugin_name_lost(
     const gchar* name,
     gpointer plugin)
 {
-    DBusNeardPlugin* self = DBUS_NEARD_PLUGIN(plugin);
+    DBusNeardPlugin* self = THIS(plugin);
 
     GERR("'%s' service already running or access denied", name);
     g_dbus_object_manager_server_set_connection(self->object_manager, NULL);
@@ -134,18 +161,137 @@ dbus_neard_plugin_name_lost(
     nfc_manager_stop(self->manager, NFC_MANAGER_PLUGIN_ERROR);
 }
 
+/*==========================================================================*
+ * NfcConfigurable
+ *==========================================================================*/
+
+static
+const char* const*
+dbus_neard_plugin_config_get_keys(
+    NfcConfigurable* config)
+{
+    static const char* const dbus_neard_plugin_keys[] = {
+        NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER,
+        NULL
+    };
+
+    return dbus_neard_plugin_keys;
+}
+
+static
+GVariant*
+dbus_neard_plugin_config_get_value(
+    NfcConfigurable* config,
+    const char* key)
+{
+    const DBusNeardOptions* options = &THIS(config)->options;
+
+    if (!g_strcmp0(NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER, key)) {
+        /* OK to return a floating reference */
+        return g_variant_new_boolean(options->bt_static_handover);
+    } else {
+        return NULL;
+    }
+}
+
+static
+gboolean
+dbus_neard_plugin_config_set_value(
+    NfcConfigurable* config,
+    const char* key,
+    GVariant* value)
+{
+    DBusNeardPlugin* self = THIS(config);
+    DBusNeardOptions* options = &self->options;
+    gboolean ok = FALSE;
+
+    if (!g_strcmp0(key, NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER)) {
+        gboolean newval = NEARD_SETTINGS_DEFAULT_BT_STATIC_HANDOVER;
+
+        if (!value) {
+            ok = TRUE;
+        } else if (g_variant_is_of_type(value, G_VARIANT_TYPE_BOOLEAN)) {
+            newval = g_variant_get_boolean(value);
+            ok = TRUE;
+        }
+
+        if (ok && options->bt_static_handover != newval) {
+            GDEBUG("%s %s", key, newval ? "on" : "off");
+            options->bt_static_handover = newval;
+            g_signal_emit(self, dbus_neard_plugin_signals
+                [SIGNAL_CONFIG_VALUE_CHANGED], g_quark_from_string(key),
+                key, value);
+        }
+    }
+    return ok;
+}
+
+static
+gulong
+dbus_neard_plugin_config_add_change_handler(
+    NfcConfigurable* config,
+    const char* key,
+    NfcConfigChangeFunc func,
+    void* user_data)
+{
+    return g_signal_connect_closure_by_id(THIS(config),
+        dbus_neard_plugin_signals[SIGNAL_CONFIG_VALUE_CHANGED],
+        key ? g_quark_from_string(key) : 0,
+        g_cclosure_new(G_CALLBACK(func), user_data, NULL), FALSE);
+}
+
+static
+void
+dbus_neard_plugin_config_init(
+    NfcConfigurableInterface* iface)
+{
+    iface->get_keys = dbus_neard_plugin_config_get_keys;
+    iface->get_value = dbus_neard_plugin_config_get_value;
+    iface->set_value = dbus_neard_plugin_config_set_value;
+    iface->add_change_handler = dbus_neard_plugin_config_add_change_handler;
+}
+
+/*==========================================================================*
+ * NfcPlugin
+ *==========================================================================*/
+
 static
 gboolean
 dbus_neard_plugin_start(
     NfcPlugin* plugin,
     NfcManager* manager)
 {
-    DBusNeardPlugin* self = DBUS_NEARD_PLUGIN(plugin);
+    const char* legacy_config_file = NEARD_SETTINGS_FILE;
+    DBusNeardPlugin* self = THIS(plugin);
+    DBusNeardOptions* options = &self->options;
     NfcAdapter** adapters;
 
     GVERBOSE("Starting");
+
+    /* Migrate the config */
+    if (g_file_test(legacy_config_file, G_FILE_TEST_EXISTS)) {
+        GKeyFile* keyfile = g_key_file_new();
+
+        GINFO("Migrating %s", legacy_config_file);
+        if (g_key_file_load_from_file(keyfile, legacy_config_file, 0, NULL)) {
+            GError* error = NULL;
+            const gboolean value = g_key_file_get_boolean(keyfile,
+                NEARD_SETTINGS_GROUP, NEARD_SETTINGS_KEY_BT_STATIC_HANDOVER,
+                &error);
+
+            if (!error) {
+                options->bt_static_handover = value;
+            } else {
+                g_error_free(error);
+                /* Keep the default value */
+            }
+        }
+        g_unlink(legacy_config_file);
+        g_key_file_unref(keyfile);
+    }
+
     self->object_manager = g_dbus_object_manager_server_new("/");
-    self->agent_manager = dbus_neard_manager_new();
+    self->agent_manager = dbus_neard_manager_new(options);
 
     /* HACK to work around GDBusObjectManagerServer not allowing to manage
      * the root path. See https://bugzilla.gnome.org/show_bug.cgi?id=761810
@@ -188,6 +334,7 @@ dbus_neard_plugin_start(
         dbus_neard_plugin_create_adapter(self, *adapters);
     }
 
+    self->settings = dbus_neard_settings_new(NFC_CONFIGURABLE(self));
     return TRUE;
 }
 
@@ -196,9 +343,10 @@ void
 dbus_neard_plugin_stop(
     NfcPlugin* plugin)
 {
-    DBusNeardPlugin* self = DBUS_NEARD_PLUGIN(plugin);
+    DBusNeardPlugin* self = THIS(plugin);
 
     GVERBOSE("Stopping");
+    dbus_neard_settings_free(self->settings);
     g_hash_table_remove_all(self->adapters);
     if (self->agent_manager) {
         dbus_neard_manager_unref(self->agent_manager);
@@ -224,6 +372,9 @@ void
 dbus_neard_plugin_init(
     DBusNeardPlugin* self)
 {
+    DBusNeardOptions* options = &self->options;
+
+    options->bt_static_handover = NEARD_SETTINGS_DEFAULT_BT_STATIC_HANDOVER;
     self->adapters = g_hash_table_new_full(g_str_hash, g_str_equal,
         NULL, dbus_neard_plugin_free_adapter);
 }
@@ -233,7 +384,7 @@ void
 dbus_neard_plugin_finalize(
     GObject* plugin)
 {
-    DBusNeardPlugin* self = DBUS_NEARD_PLUGIN(plugin);
+    DBusNeardPlugin* self = THIS(plugin);
 
     g_hash_table_destroy(self->adapters);
     G_OBJECT_CLASS(dbus_neard_plugin_parent_class)->finalize(plugin);
@@ -244,9 +395,16 @@ void
 dbus_neard_plugin_class_init(
     NfcPluginClass* klass)
 {
+    GType type = G_OBJECT_CLASS_TYPE(klass);
+
     G_OBJECT_CLASS(klass)->finalize = dbus_neard_plugin_finalize;
     klass->start = dbus_neard_plugin_start;
     klass->stop = dbus_neard_plugin_stop;
+
+    dbus_neard_plugin_signals[SIGNAL_CONFIG_VALUE_CHANGED] =
+        g_signal_new(SIGNAL_CONFIG_VALUE_CHANGED_NAME, type,
+            G_SIGNAL_RUN_FIRST | G_SIGNAL_DETAILED, 0, NULL, NULL, NULL,
+            G_TYPE_NONE, 2, G_TYPE_STRING, G_TYPE_VARIANT);
 }
 
 static
@@ -255,7 +413,7 @@ dbus_neard_plugin_create(
     void)
 {
     GDEBUG("Plugin loaded");
-    return g_object_new(DBUS_NEARD_TYPE_PLUGIN, NULL);
+    return g_object_new(THIS_TYPE, NULL);
 }
 
 NFC_PLUGIN_DEFINE(dbus_neard, "org.neard D-Bus interface",

--- a/plugins/settings/org.sailfishos.nfc.Settings.xml
+++ b/plugins/settings/org.sailfishos.nfc.Settings.xml
@@ -19,5 +19,34 @@
     <signal name="EnabledChanged">
       <arg name="enabled" type="b"/>
     </signal>
+    <!-- Interface version 2 (since nfcd 1.1.10) -->
+    <method name="GetAll2">
+      <arg name="version" type="i" direction="out"/>
+      <arg name="enabled" type="b" direction="out"/>
+      <arg name="plugin_settings" type="a(sa{sv})" direction="out"/>
+    </method>
+    <method name="GetAllPluginSettings">
+      <arg name="plugin_settings" type="a(sa{sv})" direction="out"/>
+    </method>
+    <method name="GetPluginSettings">
+      <arg name="plugin" type="s" direction="in"/>
+      <arg name="settings" type="a{sv}" direction="out"/>
+    </method>
+    <method name="GetPluginValue">
+      <arg name="plugin" type="s" direction="in"/>
+      <arg name="key" type="s" direction="in"/>
+      <arg name="value" type="v" direction="out"/>
+    </method>
+    <method name="SetPluginValue">
+      <arg name="plugin" type="s" direction="in"/>
+      <arg name="key" type="s" direction="in"/>
+      <arg name="value" type="v" direction="in"/>
+    </method>
+    <!-- Signals -->
+    <signal name="PluginValueChanged">
+      <arg name="plugin" type="s"/>
+      <arg name="key" type="s"/>
+      <arg name="value" type="v"/>
+    </signal>
   </interface>
 </node>

--- a/plugins/settings/settings_dbus_name.c
+++ b/plugins/settings/settings_dbus_name.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Jolla Ltd.
+ * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "settings_plugin.h"
+
+guint
+settings_plugin_name_own(
+    SettingsPlugin* plugin,
+    const char* name,
+    GBusAcquiredCallback bus_acquired,
+    GBusNameAcquiredCallback name_acquired,
+    GBusNameLostCallback name_lost)
+{
+    return g_bus_own_name(SETTINGS_G_BUS, name,
+        G_BUS_NAME_OWNER_FLAGS_REPLACE, bus_acquired, name_acquired,
+        name_lost, plugin, NULL);
+}
+
+void
+settings_plugin_name_unown(
+    guint id)
+{
+    g_bus_unown_name(id);
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/plugins/settings/settings_plugin.c
+++ b/plugins/settings/settings_plugin.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,20 +30,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "plugin.h"
+#include "settings_plugin.h"
 #include "settings/org.sailfishos.nfc.Settings.h"
+#include "plugin.h"
 
+#include <nfc_config.h>
 #include <nfc_manager.h>
-#include <nfc_plugin_impl.h>
-
-#include <gio/gio.h>
 
 #ifdef HAVE_DBUSACCESS
 #include <dbusaccess_policy.h>
 #include <dbusaccess_peer.h>
 #endif
 
+#include <gutil_macros.h>
 #include <gutil_misc.h>
+#include <gutil_strv.h>
 
 #include <sys/stat.h>
 #include <errno.h>
@@ -53,40 +54,71 @@
 
 GLOG_MODULE_DEFINE("settings");
 
+/*
+ * NfcConfigurable interface is utilized to configure plugins.
+ * Plugin configuration is stored in /var/lib/nfcd/settings file
+ * alongside with the global configuration, plugin names being
+ * used as section names. Configuration values are converted to
+ * strings with g_variant_print() and back to GVariants with
+ * g_variant_parse().
+ *
+ * Non-parseable values are interpreted as strings.
+ *
+ * Read-only defaults are loaded from /etc/nfcd/defaults.conf file
+ * and whatever else is found in /etc/nfcd/defaults.d directory.
+ * Those can be used for providing device-specific initial values.
+ */
+
 enum {
     SETTINGS_DBUS_CALL_GET_ALL,
     SETTINGS_DBUS_CALL_GET_INTERFACE_VERSION,
     SETTINGS_DBUS_CALL_GET_ENABLED,
     SETTINGS_DBUS_CALL_SET_ENABLED,
+    SETTINGS_DBUS_CALL_GET_ALL2,
+    SETTINGS_DBUS_CALL_GET_ALL_PLUGIN_SETTINGS,
+    SETTINGS_DBUS_CALL_GET_PLUGIN_SETTINGS,
+    SETTINGS_DBUS_CALL_GET_PLUGIN_VALUE,
+    SETTINGS_DBUS_CALL_SET_PLUGIN_VALUE,
     SETTINGS_DBUS_CALL_COUNT
 };
 
-typedef NfcPluginClass SettingsPluginClass;
 typedef struct settings_plugin {
     NfcPlugin parent;
     NfcManager* manager;
+    GHashTable* plugins; /* char* => SettingsPluginConfig */
+    GStrV* order; /* Sorted keys in plugins table */
     OrgSailfishosNfcSettings* iface;
 #ifdef HAVE_DBUSACCESS
     DAPolicy* policy;
 #endif
-    char* storage_dir;
+    GKeyFile* defaults;
     char* storage_file;
     guint own_name_id;
     gulong dbus_call_id[SETTINGS_DBUS_CALL_COUNT];
     gboolean nfc_enabled;
 } SettingsPlugin;
 
-G_DEFINE_TYPE(SettingsPlugin, settings_plugin, NFC_TYPE_PLUGIN)
-#define SETTINGS_TYPE_PLUGIN (settings_plugin_get_type())
-#define SETTINGS_PLUGIN(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), \
-        SETTINGS_TYPE_PLUGIN, SettingsPlugin))
+typedef struct settings_plugin_config {
+    const char* name;
+    SettingsPlugin* settings;
+    NfcConfigurable* config;
+    gulong change_id;
+} SettingsPluginConfig;
 
-#define SETTINGS_G_BUS                   G_BUS_TYPE_SYSTEM
-#define SETTINGS_DA_BUS                  DA_BUS_SYSTEM
+G_DEFINE_TYPE(SettingsPlugin, settings_plugin, NFC_TYPE_PLUGIN)
+#define THIS_TYPE SETTINGS_PLUGIN_TYPE
+#define THIS(obj) G_TYPE_CHECK_INSTANCE_CAST(obj, THIS_TYPE, SettingsPlugin)
+#define GET_THIS_CLASS(obj) G_TYPE_INSTANCE_GET_CLASS(obj, THIS_TYPE, \
+    SettingsPluginClass)
+
 #define SETTINGS_ERROR_(error)           SETTINGS_DBUS_SERVICE ".Error." error
 #define SETTINGS_DBUS_SERVICE            "org.sailfishos.nfc.settings"
 #define SETTINGS_DBUS_PATH               "/"
-#define SETTINGS_DBUS_INTERFACE_VERSION  (1)
+#define SETTINGS_DBUS_INTERFACE_VERSION  (2)
+
+#define SETTINGS_CONFIG_DIR              "/etc/nfcd"
+#define SETTINGS_CONFIG_DEFAULTS_FILE    "defaults.conf"
+#define SETTINGS_CONFIG_DEFAULTS_DIR     "defaults.d"
 
 #define SETTINGS_STORAGE_DIR             "/var/lib/nfcd"
 #define SETTINGS_STORAGE_FILE            "settings"
@@ -96,20 +128,28 @@ G_DEFINE_TYPE(SettingsPlugin, settings_plugin, NFC_TYPE_PLUGIN)
 #define SETTINGS_KEY_ENABLED             "Enabled"
 #define SETTINGS_KEY_ALWAYS_ON           "AlwaysOn"
 
-#ifdef HAVE_DBUSACCESS
-
 typedef enum settings_error {
     SETTINGS_ERROR_ACCESS_DENIED,        /* AccessDenied */
+    SETTINGS_ERROR_FAILED,               /* Failed */
+    SETTINGS_ERROR_UNKNOWN_PLUGIN,       /* UnknownPlugin */
+    SETTINGS_ERROR_UNKNOWN_KEY,          /* UnknownKey */
     SETTINGS_NUM_ERRORS
 } SETTINGS_ERROR;
 
 #define SETTINGS_DBUS_ERROR (settings_plugin_error_quark())
+
+#ifdef HAVE_DBUSACCESS
 
 typedef enum nfc_settings_action {
     SETTINGS_ACTION_GET_ALL = 1,
     SETTINGS_ACTION_GET_INTERFACE_VERSION,
     SETTINGS_ACTION_GET_ENABLED,
     SETTINGS_ACTION_SET_ENABLED,
+    SETTINGS_ACTION_GET_ALL2,
+    SETTINGS_ACTION_GET_ALL_PLUGIN_SETTINGS,
+    SETTINGS_ACTION_GET_PLUGIN_SETTINGS,
+    SETTINGS_ACTION_GET_PLUGIN_VALUE,
+    SETTINGS_ACTION_SET_PLUGIN_VALUE
 } SETTINGS_ACTION;
 
 static const DA_ACTION settings_policy_actions[] = {
@@ -117,18 +157,71 @@ static const DA_ACTION settings_policy_actions[] = {
     { "GetInterfaceVersion", SETTINGS_ACTION_GET_INTERFACE_VERSION, 0 },
     { "GetEnabled", SETTINGS_ACTION_GET_ENABLED, 0 },
     { "SetEnabled", SETTINGS_ACTION_SET_ENABLED, 0 },
+    { "GetAll2", SETTINGS_ACTION_GET_ALL2, 0 },
+    { "GetAllPluginSettings", SETTINGS_ACTION_GET_ALL_PLUGIN_SETTINGS, 0 },
+    { "GetPluginSettings", SETTINGS_ACTION_GET_PLUGIN_SETTINGS, 0 },
+    { "GetPluginValue", SETTINGS_ACTION_GET_PLUGIN_VALUE, 0 },
+    { "SetPluginValue", SETTINGS_ACTION_SET_PLUGIN_VALUE, 1 },
     { NULL }
 };
 
-#define SETTINGS_DEFAULT_ACCESS_GET_ALL               DA_ACCESS_ALLOW
-#define SETTINGS_DEFAULT_ACCESS_GET_INTERFACE_VERSION DA_ACCESS_ALLOW
-#define SETTINGS_DEFAULT_ACCESS_GET_ENABLED           DA_ACCESS_ALLOW
-#define SETTINGS_DEFAULT_ACCESS_SET_ENABLED           DA_ACCESS_DENY
+#define SETTINGS_DEFAULT_ACCESS_GET_ALL                 DA_ACCESS_ALLOW
+#define SETTINGS_DEFAULT_ACCESS_GET_INTERFACE_VERSION   DA_ACCESS_ALLOW
+#define SETTINGS_DEFAULT_ACCESS_GET_ENABLED             DA_ACCESS_ALLOW
+#define SETTINGS_DEFAULT_ACCESS_SET_ENABLED             DA_ACCESS_DENY
+#define SETTINGS_DEFAULT_ACCESS_GET_ALL2                DA_ACCESS_ALLOW
+#define SETTINGS_DEFAULT_ACCESS_GET_ALL_PLUGIN_SETTINGS DA_ACCESS_ALLOW
+#define SETTINGS_DEFAULT_ACCESS_GET_PLUGIN_SETTINGS     DA_ACCESS_ALLOW
+#define SETTINGS_DEFAULT_ACCESS_GET_PLUGIN_VALUE        DA_ACCESS_ALLOW
+#define SETTINGS_DEFAULT_ACCESS_SET_PLUGIN_VALUE        DA_ACCESS_DENY
 
 static const char settings_default_policy[] =
     DA_POLICY_VERSION ";group(privileged)=allow";
 
 #endif /* HAVE_DBUSACCESS */
+
+static
+void
+settings_plugin_merge_config_group(
+    GKeyFile* dest,
+    GKeyFile* src,
+    const char* group)
+{
+    gsize i, n = 0;
+    char** keys = g_key_file_get_keys(src, group, &n, NULL);
+
+    for (i = 0; i < n; i++) {
+        const char* key = keys[i];
+        char* value = g_key_file_get_value(src, group, key, NULL);
+
+        g_key_file_set_value(dest, group, key, value);
+        g_free(value);
+    }
+
+    g_strfreev(keys);
+}
+
+static
+void
+settings_plugin_merge_defaults(
+    SettingsPlugin* self,
+    GKeyFile* src)
+{
+    gsize i, n = 0;
+    char** groups = g_key_file_get_groups(src, &n);
+
+    for (i = 0; i < n; i++) {
+        const char* group = groups[i];
+
+        if (!strcmp(group, SETTINGS_GROUP) ||
+            g_hash_table_contains(self->plugins, group)) {
+            settings_plugin_merge_config_group(self->defaults, src, group);
+        } else {
+            GDEBUG("Skipping defaults group [%s]", group);
+        }
+    }
+    g_strfreev(groups);
+}
 
 static
 GKeyFile*
@@ -147,7 +240,9 @@ settings_plugin_save_config(
     SettingsPlugin* self,
     GKeyFile* config)
 {
-    if (!g_mkdir_with_parents(self->storage_dir, SETTINGS_STORAGE_DIR_PERM)) {
+    const char* storage_dir = GET_THIS_CLASS(self)->storage_dir;
+
+    if (!g_mkdir_with_parents(storage_dir, SETTINGS_STORAGE_DIR_PERM)) {
         GError* error = NULL;
         gsize len;
         gchar* data = g_key_file_to_data(config, &len, NULL);
@@ -165,13 +260,14 @@ settings_plugin_save_config(
         }
         g_free(data);
     } else {
-        GWARN("Failed to create directory %s", self->storage_dir);
+        GWARN("Failed to create directory %s", storage_dir);
     }
 }
 
 static
 gboolean
 settings_plugin_get_boolean(
+    SettingsPlugin* self,
     GKeyFile* config,
     const char* key,
     gboolean defval)
@@ -180,28 +276,139 @@ settings_plugin_get_boolean(
     gboolean val = g_key_file_get_boolean(config, SETTINGS_GROUP, key, &error);
 
     if (error) {
-        g_error_free(error);
-        /* Default */
-        return defval;
-    } else {
-        return val;
+        g_clear_error(&error);
+        val = g_key_file_get_boolean(self->defaults, SETTINGS_GROUP, key,
+            &error);
+        if (error) {
+            g_error_free(error);
+            /* Default */
+            return defval;
+        }
     }
+    return val;
 }
 
 static
 gboolean
 settings_plugin_nfc_enabled(
+    SettingsPlugin* self,
     GKeyFile* config)
 {
-    return settings_plugin_get_boolean(config, SETTINGS_KEY_ENABLED, TRUE);
+    return settings_plugin_get_boolean(self, config,
+        SETTINGS_KEY_ENABLED, TRUE);
 }
 
 static
 gboolean
 settings_plugin_nfc_always_on(
+    SettingsPlugin* self,
     GKeyFile* config)
 {
-    return settings_plugin_get_boolean(config, SETTINGS_KEY_ALWAYS_ON, FALSE);
+    return settings_plugin_get_boolean(self, config,
+        SETTINGS_KEY_ALWAYS_ON, FALSE);
+}
+
+static
+gboolean
+settings_plugin_update_boolean(
+    SettingsPlugin* self,
+    GKeyFile* config,
+    const char* key,
+    gboolean value)
+{
+    const char* group = SETTINGS_GROUP;
+    GError* error = NULL;
+    gboolean default_value = g_key_file_get_boolean(self->defaults, group,
+        key, &error);
+    gboolean have_default = !error;
+    gboolean config_value;
+
+    g_clear_error(&error);
+    config_value = g_key_file_get_boolean(config, group, key, &error);
+    if (error) {
+        g_error_free(error);
+        /* Save it only if it's not the default value */
+        if (!have_default || value != default_value) {
+            g_key_file_set_boolean(config, group, key, value);
+            return TRUE;
+        }
+    } else if (have_default && value == default_value) {
+        /* Remove the default value from the config */
+        g_key_file_remove_key(config, group, key, NULL);
+        return TRUE;
+    } else if (config_value != value) {
+        /* Not a default and doesn't match the config - save it */
+        g_key_file_set_boolean(config, group, key, value);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static
+gboolean
+settings_plugin_update_settings(
+    SettingsPlugin* self,
+    GKeyFile* config)
+{
+    GStrV* plugins = self->order;
+    gboolean save = FALSE;
+
+    if (settings_plugin_update_boolean(self, config, SETTINGS_KEY_ENABLED,
+        self->nfc_enabled)) {
+        save = TRUE;
+    }
+
+    /* Check plugin configs */
+    if (plugins) {
+        while (*plugins) {
+            const char* group = *plugins++;
+            const SettingsPluginConfig* pc = g_hash_table_lookup(self->plugins,
+                group);
+            const char* const* keys = nfc_config_get_keys(pc->config);
+
+            if (keys) {
+                const char* const* ptr = keys;
+
+                while (*ptr) {
+                    const char* key = *ptr++;
+                    GVariant* value = nfc_config_get_value(pc->config, key);
+                    char* str = g_key_file_get_string(config, group, key, NULL);
+                    char* defval = g_key_file_get_string(self->defaults,
+                        group, key, NULL);
+                    char* sval = NULL;
+
+                    if (value) {
+                        sval = g_variant_print(value, FALSE);
+                        g_variant_unref(value);
+                    }
+
+                    if (sval && defval && !strcmp(sval, defval)) {
+                        /* Don't store the default value */
+                        GVERBOSE_("[%s] %s %s => (default)", group,
+                            key, sval);
+                        if (g_key_file_remove_key(config, group, key, NULL)) {
+                            save = TRUE;
+                        }
+                    } else if (g_strcmp0(sval, str)) {
+                        GVERBOSE_("[%s] %s %s => %s", group, key, str, sval);
+                        if (sval) {
+                            g_key_file_set_string(config, group, key, sval);
+                            save = TRUE;
+                        } else if (g_key_file_remove_key(config, group, key,
+                            NULL)) {
+                            save = TRUE;
+                        }
+                    }
+
+                    g_free(defval);
+                    g_free(sval);
+                    g_free(str);
+                }
+            }
+        }
+    }
+
+    return save;
 }
 
 static
@@ -210,23 +417,68 @@ settings_plugin_update_config(
     SettingsPlugin* self)
 {
     GKeyFile* config = settings_plugin_load_config(self);
-    const gboolean enabled = settings_plugin_nfc_enabled(config);
-    gboolean save = FALSE;
 
-    if (enabled != self->nfc_enabled) {
-        save = TRUE;
-        g_key_file_set_boolean(config, SETTINGS_GROUP, SETTINGS_KEY_ENABLED,
-            self->nfc_enabled);
-    }
-
-    if (save) {
+    if (settings_plugin_update_settings(self, config)) {
         settings_plugin_save_config(self, config);
     }
 
     g_key_file_unref(config);
 }
 
-#ifdef HAVE_DBUSACCESS
+static
+gboolean
+settings_plugin_is_valid_key(
+    NfcConfigurable* config,
+    const char* key)
+{
+    return gutil_strv_contains((const GStrV*)nfc_config_get_keys(config), key);
+}
+
+static
+GVariant* /* floating */
+settings_plugin_config_variant(
+    NfcConfigurable* config)
+{
+    GVariantBuilder b;
+    g_variant_builder_init(&b, G_VARIANT_TYPE_VARDICT);
+    const char* const* ptr = nfc_config_get_keys(config);
+
+    if (ptr) {
+        while (*ptr) {
+            const char* key = *ptr++;
+            GVariant* value = nfc_config_get_value(config, key);
+
+            if (value) {
+                g_variant_builder_add(&b, "{sv}", key, value);
+                g_variant_unref(value);
+            }
+        }
+    }
+    return g_variant_builder_end(&b);
+}
+
+static
+GVariant* /* floating */
+settings_plugin_get_all_plugin_settings(
+    SettingsPlugin* self)
+{
+    GVariantBuilder b;
+    char* const* ptr = self->order;
+
+    g_variant_builder_init(&b, G_VARIANT_TYPE("a(sa{sv})"));
+    if (ptr) {
+        while (*ptr) {
+            const char* name = *ptr++;
+            const SettingsPluginConfig* pc = g_hash_table_lookup(self->plugins,
+                name);
+
+            g_variant_builder_add(&b, "(s@a{sv})", name,
+                settings_plugin_config_variant(pc->config));
+        }
+    }
+
+    return g_variant_builder_end(&b);
+}
 
 static
 GQuark
@@ -235,6 +487,9 @@ settings_plugin_error_quark()
     static volatile gsize settings_error_quark_value = 0;
     static const GDBusErrorEntry errors[] = {
         { SETTINGS_ERROR_ACCESS_DENIED, SETTINGS_ERROR_("AccessDenied") },
+        { SETTINGS_ERROR_FAILED, SETTINGS_ERROR_("Failed") },
+        { SETTINGS_ERROR_UNKNOWN_PLUGIN, SETTINGS_ERROR_("UnknownPlugin") },
+        { SETTINGS_ERROR_UNKNOWN_KEY, SETTINGS_ERROR_("UnknownKey") }
     };
 
     g_dbus_error_register_error_domain("dbus-nfc-settings-error-quark",
@@ -242,16 +497,19 @@ settings_plugin_error_quark()
     return (GQuark)settings_error_quark_value;
 }
 
+#ifdef HAVE_DBUSACCESS
+
 /*
  * Note: if settings_plugin_access_allowed() returns FALSE, it completes
- * the call with error.
+ * the call with AccessDenied error.
  */
 static
 gboolean
-settings_plugin_access_allowed(
+settings_plugin_access_allowed1(
     SettingsPlugin* self,
     GDBusMethodInvocation* call,
     SETTINGS_ACTION action,
+    const char* arg,
     DA_ACCESS def)
 {
     const char* sender = g_dbus_method_invocation_get_sender(call);
@@ -260,7 +518,7 @@ settings_plugin_access_allowed(
     /* If we get no peer information from dbus-daemon, it means that
      * the peer is gone so it doesn't really matter what we do in this
      * case - the reply will be dropped anyway. */
-    if (peer && da_policy_check(self->policy, &peer->cred, action, 0, def) ==
+    if (peer && da_policy_check(self->policy, &peer->cred, action, arg, def) ==
         DA_ACCESS_ALLOW) {
         return TRUE;
     }
@@ -272,10 +530,12 @@ settings_plugin_access_allowed(
 #else
 
 /* No access control (other than the one provided by dbus-daemon) */
-#define settings_plugin_access_allowed(self,call,action,def) (TRUE)
+#define settings_plugin_access_allowed1(self,call,action,arg,def) (TRUE)
 
 #endif /* HAVE_DBUSACCESS */
 
+#define settings_plugin_access_allowed(self,call,action,def) \
+    settings_plugin_access_allowed1(self, call, action, NULL, def)
 
 static
 void
@@ -299,8 +559,12 @@ settings_plugin_dbus_handle_get_all(
     GDBusMethodInvocation* call,
     gpointer user_data)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(user_data);
+    SettingsPlugin* self = THIS(user_data);
 
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
     if (settings_plugin_access_allowed(self, call,
         SETTINGS_ACTION_GET_ALL, SETTINGS_DEFAULT_ACCESS_GET_ALL)) {
         org_sailfishos_nfc_settings_complete_get_all(iface, call,
@@ -316,7 +580,11 @@ settings_plugin_dbus_handle_get_interface_version(
     GDBusMethodInvocation* call,
     gpointer user_data)
 {
-    if (settings_plugin_access_allowed(SETTINGS_PLUGIN(user_data), call,
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
+    if (settings_plugin_access_allowed(THIS(user_data), call,
         SETTINGS_ACTION_GET_INTERFACE_VERSION,
         SETTINGS_DEFAULT_ACCESS_GET_INTERFACE_VERSION)) {
         org_sailfishos_nfc_settings_complete_get_interface_version(iface, call,
@@ -332,8 +600,12 @@ settings_plugin_dbus_handle_get_enabled(
     GDBusMethodInvocation* call,
     gpointer user_data)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(user_data);
+    SettingsPlugin* self = THIS(user_data);
 
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
     if (settings_plugin_access_allowed(self, call,
         SETTINGS_ACTION_GET_ENABLED, SETTINGS_DEFAULT_ACCESS_GET_ENABLED)) {
         org_sailfishos_nfc_settings_complete_get_enabled(iface, call,
@@ -350,12 +622,178 @@ settings_plugin_dbus_handle_set_enabled(
     gboolean enabled,
     gpointer user_data)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(user_data);
+    SettingsPlugin* self = THIS(user_data);
 
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
     if (settings_plugin_access_allowed(self, call,
         SETTINGS_ACTION_SET_ENABLED, SETTINGS_DEFAULT_ACCESS_SET_ENABLED)) {
         settings_plugin_set_nfc_enabled(self, enabled);
         org_sailfishos_nfc_settings_complete_set_enabled(iface, call);
+    }
+    return TRUE;
+}
+
+static
+gboolean
+settings_plugin_dbus_handle_get_all2(
+    OrgSailfishosNfcSettings* iface,
+    GDBusMethodInvocation* call,
+    gpointer user_data)
+{
+    SettingsPlugin* self = THIS(user_data);
+
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
+    if (settings_plugin_access_allowed(self, call,
+        SETTINGS_ACTION_GET_ALL2, SETTINGS_DEFAULT_ACCESS_GET_ALL2)) {
+        org_sailfishos_nfc_settings_complete_get_all2(iface, call,
+            SETTINGS_DBUS_INTERFACE_VERSION, self->nfc_enabled,
+            settings_plugin_get_all_plugin_settings(self));
+    }
+    return TRUE;
+}
+
+static
+gboolean
+settings_plugin_dbus_handle_get_all_plugin_settings(
+    OrgSailfishosNfcSettings* iface,
+    GDBusMethodInvocation* call,
+    gpointer user_data)
+{
+    SettingsPlugin* self = THIS(user_data);
+
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
+    if (settings_plugin_access_allowed(self, call,
+        SETTINGS_ACTION_GET_ALL_PLUGIN_SETTINGS,
+        SETTINGS_DEFAULT_ACCESS_GET_ALL_PLUGIN_SETTINGS)) {
+        org_sailfishos_nfc_settings_complete_get_all_plugin_settings(iface,
+            call, settings_plugin_get_all_plugin_settings(self));
+    }
+    return TRUE;
+}
+
+static
+gboolean
+settings_plugin_dbus_handle_get_plugin_settings(
+    OrgSailfishosNfcSettings* iface,
+    GDBusMethodInvocation* call,
+    const char* plugin,
+    gpointer user_data)
+{
+    SettingsPlugin* self = THIS(user_data);
+
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
+    if (settings_plugin_access_allowed(self, call,
+        SETTINGS_ACTION_GET_PLUGIN_SETTINGS,
+        SETTINGS_DEFAULT_ACCESS_GET_PLUGIN_SETTINGS)) {
+        const SettingsPluginConfig* pc = g_hash_table_lookup(self->plugins,
+            plugin);
+
+        if (pc) {
+            org_sailfishos_nfc_settings_complete_get_plugin_settings(iface,
+              call, settings_plugin_config_variant(pc->config));
+        } else {
+            g_dbus_method_invocation_return_error_literal(call,
+                SETTINGS_DBUS_ERROR, SETTINGS_ERROR_UNKNOWN_PLUGIN, plugin);
+        }
+    }
+    return TRUE;
+}
+
+static
+gboolean
+settings_plugin_dbus_handle_get_plugin_value(
+    OrgSailfishosNfcSettings* iface,
+    GDBusMethodInvocation* call,
+    const char* plugin,
+    const char* key,
+    gpointer user_data)
+{
+    SettingsPlugin* self = THIS(user_data);
+
+    /*
+     * N.B. If settings_plugin_access_allowed() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
+    if (settings_plugin_access_allowed(self, call,
+        SETTINGS_ACTION_GET_PLUGIN_VALUE,
+        SETTINGS_DEFAULT_ACCESS_GET_PLUGIN_VALUE)) {
+        const SettingsPluginConfig* pc = g_hash_table_lookup(self->plugins,
+            plugin);
+
+        if (pc) {
+            GVariant* value = nfc_config_get_value(pc->config, key);
+
+            if (value) {
+                org_sailfishos_nfc_settings_complete_get_plugin_value(iface,
+                    call, g_variant_new_variant(value));
+                g_variant_unref(value);
+            } else {
+                /* What else could be wrong? */
+                g_dbus_method_invocation_return_error_literal(call,
+                    SETTINGS_DBUS_ERROR, SETTINGS_ERROR_UNKNOWN_KEY, key);
+            }
+        } else {
+            g_dbus_method_invocation_return_error_literal(call,
+                SETTINGS_DBUS_ERROR, SETTINGS_ERROR_UNKNOWN_PLUGIN, plugin);
+        }
+    }
+    return TRUE;
+}
+
+static
+gboolean
+settings_plugin_dbus_handle_set_plugin_value(
+    OrgSailfishosNfcSettings* iface,
+    GDBusMethodInvocation* call,
+    const char* plugin,
+    const char* key,
+    GVariant* var,
+    gpointer user_data)
+{
+    SettingsPlugin* self = THIS(user_data);
+
+    /*
+     * N.B. If settings_plugin_access_allowed1() denies the access,
+     * it completes the call with AccessDenied error and returns FALSE.
+     */
+    if (settings_plugin_access_allowed1(self, call,
+        SETTINGS_ACTION_SET_PLUGIN_VALUE, plugin,
+        SETTINGS_DEFAULT_ACCESS_SET_PLUGIN_VALUE)) {
+        const SettingsPluginConfig* pc = g_hash_table_lookup(self->plugins,
+            plugin);
+
+        if (pc) {
+            GVariant* value =
+                g_variant_is_of_type(var, G_VARIANT_TYPE_VARIANT) ?
+                    g_variant_get_variant(var) : g_variant_ref_sink(var);
+
+            if (nfc_config_set_value(pc->config, key, value)) {
+                org_sailfishos_nfc_settings_complete_set_plugin_value(iface,
+                    call);
+            } else if (!settings_plugin_is_valid_key(pc->config, key)) {
+                g_dbus_method_invocation_return_error_literal(call,
+                    SETTINGS_DBUS_ERROR, SETTINGS_ERROR_UNKNOWN_KEY, key);
+            } else {
+                g_dbus_method_invocation_return_error_literal(call,
+                    SETTINGS_DBUS_ERROR, SETTINGS_ERROR_FAILED, key);
+            }
+            g_variant_unref(value);
+        } else {
+            g_dbus_method_invocation_return_error_literal(call,
+                SETTINGS_DBUS_ERROR, SETTINGS_ERROR_UNKNOWN_PLUGIN, plugin);
+        }
     }
     return TRUE;
 }
@@ -367,10 +805,9 @@ settings_plugin_dbus_connected(
     const gchar* name,
     gpointer plugin)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(plugin);
+    SettingsPlugin* self = THIS(plugin);
     GError* error = NULL;
 
-    GDEBUG("Acquired service name '%s'", name);
     if (!g_dbus_interface_skeleton_export(G_DBUS_INTERFACE_SKELETON
         (self->iface), connection, SETTINGS_DBUS_PATH, &error)) {
         GERR("%s", GERRMSG(error));
@@ -395,11 +832,189 @@ settings_plugin_dbus_name_lost(
     const gchar* name,
     gpointer plugin)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(plugin);
+    SettingsPlugin* self = THIS(plugin);
 
     GERR("'%s' service already running or access denied", name);
     /* Tell daemon to exit */
     nfc_manager_stop(self->manager, NFC_MANAGER_PLUGIN_ERROR);
+}
+
+static
+void
+settings_plugin_config_changed(
+    NfcConfigurable* config,
+    const char* key,
+    GVariant* value,
+    void* user_data)
+{
+    SettingsPluginConfig* pc = user_data;
+    SettingsPlugin* self = pc->settings;
+
+    org_sailfishos_nfc_settings_emit_plugin_value_changed(self->iface,
+        pc->name, key, g_variant_new_variant(value));
+    settings_plugin_update_config(self);
+}
+
+static
+void
+settings_plugin_config_free(
+    gpointer user_data)
+{
+    SettingsPluginConfig* pc = user_data;
+
+    nfc_config_remove_handler(pc->config, pc->change_id);
+    gutil_slice_free(pc);
+}
+
+static
+void
+settings_plugin_load_defaults(
+    SettingsPlugin* self)
+{
+    const char* config_dir = GET_THIS_CLASS(self)->config_dir;
+    char* defaults_file = g_build_filename(config_dir,
+        SETTINGS_CONFIG_DEFAULTS_FILE, NULL);
+    char* defaults_dir_name = g_build_filename(config_dir,
+        SETTINGS_CONFIG_DEFAULTS_DIR, NULL);
+    GDir* defaults_dir = g_dir_open(defaults_dir_name, 0, NULL);
+
+    /*
+     * Note that this is done twice - before and after loading all plugins.
+     * First time only the global defaults (i.e. the [Settings] section) get
+     * pulled in.
+     */
+    g_key_file_load_from_file(self->defaults, defaults_file, 0, NULL);
+    if (defaults_dir) {
+        const char* name;
+        GPtrArray* buf = g_ptr_array_new();
+
+        while ((name = g_dir_read_name(defaults_dir)) != NULL) {
+            char* path = g_build_filename(defaults_dir_name, name, NULL);
+
+            if (g_file_test(path, G_FILE_TEST_IS_REGULAR)) {
+                g_ptr_array_add(buf, path);
+            } else {
+                g_free(path);
+            }
+        }
+
+        if (buf->len) {
+            GKeyFile* overwrite = g_key_file_new();
+            char** names;
+            char** ptr;
+
+            /* NULL-terminate the list */
+            g_ptr_array_add(buf, NULL);
+
+            /* Sort the names */
+            ptr = names = gutil_strv_sort((char**)
+                g_ptr_array_free(buf, FALSE), TRUE);
+            while (*ptr) {
+                const char* file = *ptr++;
+
+                if (g_key_file_load_from_file(overwrite, file, 0, NULL)) {
+                    settings_plugin_merge_defaults(self, overwrite);
+                }
+            }
+            g_strfreev(names);
+            g_key_file_unref(overwrite);
+        } else {
+            g_ptr_array_free(buf, TRUE);
+        }
+        g_dir_close(defaults_dir);
+    }
+
+    g_free(defaults_file);
+    g_free(defaults_dir_name);
+}
+
+static
+void
+settings_plugin_started(
+    NfcPlugin* plugin)
+{
+    SettingsPlugin* self = THIS(plugin);
+    NfcPlugin* const* plugins = nfc_manager_plugins(self->manager);
+    NfcPlugin* const* ptr = plugins;
+    GPtrArray* buf = g_ptr_array_new();
+    GKeyFile* config = settings_plugin_load_config(self);
+    char** names;
+
+    /* All functional plugins have been successfully started */
+    while (*ptr) {
+        NfcPlugin* p = *ptr++;
+
+        if (NFC_IS_CONFIGURABLE(p)) {
+            char* name = g_strdup(p->desc->name);
+            SettingsPluginConfig* pc = g_slice_new(SettingsPluginConfig);
+
+            GDEBUG("Plugin '%s' is configurable", name);
+            pc->name = name;
+            pc->settings = self;
+            pc->config = NFC_CONFIGURABLE(p);
+            g_hash_table_insert(self->plugins, name, pc);
+            g_ptr_array_add(buf, name);
+        }
+    }
+
+    /* NULL-terminate and sort the array */
+    g_ptr_array_add(buf, NULL);
+    self->order = gutil_strv_sort((char**)
+        g_ptr_array_free(buf, FALSE), TRUE);
+
+    /* Apply the initial configuration and register change listeners */
+    settings_plugin_load_defaults(self);
+    names = self->order;
+    while (*names) {
+        const char* name = *names++;
+        SettingsPluginConfig* pc = g_hash_table_lookup(self->plugins, name);
+        const char* const* keys = nfc_config_get_keys(pc->config);
+
+        if (keys) {
+            while (*keys) {
+                const char* key = *keys++;
+                char* str = g_key_file_get_string(config, name, key, NULL);
+
+                if (!str) {
+                    str = g_key_file_get_string(self->defaults, name, key,
+                        NULL);
+                }
+                if (str) {
+                    GVariant* var = g_variant_parse(NULL, str, NULL, NULL,
+                        NULL);
+
+                    if (!var) {
+                        /* Interpret unparseable values as strings */
+                        GDEBUG("Unable to parse [%s] %s=%s", name, key, str);
+                        var = g_variant_ref_sink(g_variant_new_string(str));
+                    }
+                    nfc_config_set_value(pc->config, key, var);
+                    g_variant_unref(var);
+                    g_free(str);
+                }
+            }
+        }
+
+        /* Now we can listen for changes */
+        pc->change_id = nfc_config_add_change_handler(pc->config, NULL,
+            settings_plugin_config_changed, pc);
+    }
+
+    /* Apply global values */
+    self->nfc_enabled = settings_plugin_nfc_enabled(self, config);
+    GINFO("NFC %s", self->nfc_enabled ? "enabled" : "disabled");
+    nfc_manager_set_enabled(self->manager, self->nfc_enabled);
+
+    if (settings_plugin_nfc_always_on(self, config)) {
+        nfc_manager_request_power(self->manager, TRUE);
+    }
+
+    /* Check the config (mostly for dbus_neard migration) */
+    if (settings_plugin_update_settings(self, config)) {
+        settings_plugin_save_config(self, config);
+    }
+
+    g_key_file_unref(config);
 }
 
 static
@@ -408,8 +1023,7 @@ settings_plugin_start(
     NfcPlugin* plugin,
     NfcManager* manager)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(plugin);
-    GKeyFile* config;
+    SettingsPlugin* self = THIS(plugin);
 
     GVERBOSE("Starting");
     self->manager = nfc_manager_ref(manager);
@@ -426,19 +1040,25 @@ settings_plugin_start(
     self->dbus_call_id[SETTINGS_DBUS_CALL_SET_ENABLED] =
         g_signal_connect(self->iface, "handle-set-enabled",
         G_CALLBACK(settings_plugin_dbus_handle_set_enabled), self);
+    self->dbus_call_id[SETTINGS_DBUS_CALL_GET_ALL2] =
+        g_signal_connect(self->iface, "handle-get-all2",
+        G_CALLBACK(settings_plugin_dbus_handle_get_all2), self);
+    self->dbus_call_id[SETTINGS_DBUS_CALL_GET_ALL_PLUGIN_SETTINGS] =
+        g_signal_connect(self->iface, "handle-get-all-plugin-settings",
+        G_CALLBACK(settings_plugin_dbus_handle_get_all_plugin_settings), self);
+    self->dbus_call_id[SETTINGS_DBUS_CALL_GET_PLUGIN_SETTINGS] =
+        g_signal_connect(self->iface, "handle-get-plugin-settings",
+        G_CALLBACK(settings_plugin_dbus_handle_get_plugin_settings), self);
+    self->dbus_call_id[SETTINGS_DBUS_CALL_GET_PLUGIN_VALUE] =
+        g_signal_connect(self->iface, "handle-get-plugin-value",
+        G_CALLBACK(settings_plugin_dbus_handle_get_plugin_value), self);
+    self->dbus_call_id[SETTINGS_DBUS_CALL_SET_PLUGIN_VALUE] =
+        g_signal_connect(self->iface, "handle-set-plugin-value",
+        G_CALLBACK(settings_plugin_dbus_handle_set_plugin_value), self);
 
-    self->own_name_id = g_bus_own_name(SETTINGS_G_BUS, SETTINGS_DBUS_SERVICE,
-        G_BUS_NAME_OWNER_FLAGS_REPLACE, settings_plugin_dbus_connected,
-        settings_plugin_dbus_name_acquired, settings_plugin_dbus_name_lost,
-        self, NULL);
-
-    config = settings_plugin_load_config(self);
-    if (settings_plugin_nfc_always_on(config)) {
-        nfc_manager_request_power(self->manager, TRUE);
-    }
-    settings_plugin_set_nfc_enabled(self, settings_plugin_nfc_enabled(config));
-    nfc_manager_set_enabled(self->manager, self->nfc_enabled);
-    g_key_file_unref(config);
+    self->own_name_id = settings_plugin_name_own(self, SETTINGS_DBUS_SERVICE,
+        settings_plugin_dbus_connected, settings_plugin_dbus_name_acquired,
+        settings_plugin_dbus_name_lost);
     return TRUE;
 }
 
@@ -447,11 +1067,12 @@ void
 settings_plugin_stop(
     NfcPlugin* plugin)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(plugin);
+    SettingsPlugin* self = THIS(plugin);
 
     GVERBOSE("Stopping");
+    g_hash_table_remove_all(self->plugins);
     if (self->own_name_id) {
-        g_bus_unown_name(self->own_name_id);
+        settings_plugin_name_unown(self->own_name_id);
         self->own_name_id = 0;
     }
     if (self->iface) {
@@ -473,9 +1094,11 @@ void
 settings_plugin_init(
     SettingsPlugin* self)
 {
-    self->storage_dir = g_strdup(SETTINGS_STORAGE_DIR);
-    self->storage_file = g_build_filename(self->storage_dir,
+    self->defaults = g_key_file_new();
+    self->storage_file = g_build_filename(GET_THIS_CLASS(self)->storage_dir,
         SETTINGS_STORAGE_FILE, NULL);
+    self->plugins = g_hash_table_new_full(g_str_hash, g_str_equal,
+        NULL, settings_plugin_config_free);
 #ifdef HAVE_DBUSACCESS
     self->policy = da_policy_new_full(settings_default_policy,
         settings_policy_actions);
@@ -487,24 +1110,32 @@ void
 settings_plugin_finalize(
     GObject* plugin)
 {
-    SettingsPlugin* self = SETTINGS_PLUGIN(plugin);
+    SettingsPlugin* self = THIS(plugin);
 
 #ifdef HAVE_DBUSACCESS
     da_policy_unref(self->policy);
 #endif
-    g_free(self->storage_dir);
     g_free(self->storage_file);
+    g_strfreev(self->order);
+    g_key_file_unref(self->defaults);
+    g_hash_table_destroy(self->plugins);
     G_OBJECT_CLASS(settings_plugin_parent_class)->finalize(plugin);
 }
 
 static
 void
 settings_plugin_class_init(
-    NfcPluginClass* klass)
+    SettingsPluginClass* klass)
 {
-    G_OBJECT_CLASS(klass)->finalize = settings_plugin_finalize;
-    klass->start = settings_plugin_start;
-    klass->stop = settings_plugin_stop;
+    GObjectClass* object_class = G_OBJECT_CLASS(klass);
+    NfcPluginClass* plugin_class = NFC_PLUGIN_CLASS(klass);
+
+    object_class->finalize = settings_plugin_finalize;
+    plugin_class->start = settings_plugin_start;
+    plugin_class->stop = settings_plugin_stop;
+    plugin_class->started = settings_plugin_started;
+    klass->storage_dir = SETTINGS_STORAGE_DIR;
+    klass->config_dir = SETTINGS_CONFIG_DIR;
 }
 
 static
@@ -513,7 +1144,7 @@ settings_plugin_create(
     void)
 {
     GDEBUG("Plugin loaded");
-    return g_object_new(SETTINGS_TYPE_PLUGIN, NULL);
+    return g_object_new(THIS_TYPE, NULL);
 }
 
 NFC_PLUGIN_DEFINE(settings, "Settings storage and D-Bus interface",

--- a/plugins/settings/settings_plugin.h
+++ b/plugins/settings/settings_plugin.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Jolla Ltd.
+ * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SETTINGS_PLUGIN_IMPL_H
+#define SETTINGS_PLUGIN_IMPL_H
+
+/* Internal header file for settings plugin implementation */
+
+#include <nfc_plugin_impl.h>
+
+#define GLOG_MODULE_NAME settings_log
+#include <gutil_log.h>
+
+#include <gio/gio.h>
+
+#define SETTINGS_G_BUS           G_BUS_TYPE_SYSTEM
+#define SETTINGS_DA_BUS          DA_BUS_SYSTEM
+
+/* Class structure is exposed for unit testing */
+typedef struct settings_plugin SettingsPlugin;
+typedef struct settings_plugin_class {
+    NfcPluginClass parent;
+    const char* storage_dir;
+    const char* config_dir;
+} SettingsPluginClass;
+
+GType settings_plugin_get_type(void);
+#define SETTINGS_PLUGIN_TYPE settings_plugin_get_type()
+
+/* And these are also separated so that unit test can substitute them */
+guint
+settings_plugin_name_own(
+    SettingsPlugin* plugin,
+    const char* name,
+    GBusAcquiredCallback bus_acquired,
+    GBusNameAcquiredCallback name_acquired,
+    GBusNameLostCallback name_lost);
+
+void
+settings_plugin_name_unown(
+    guint id);
+
+#endif /* SETTINGS_PLUGIN_IMPL_H */
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/nfcd.map
+++ b/src/nfcd.map
@@ -1,6 +1,8 @@
 {
     global:
         nfc_adapter_*;
+        nfc_config_*;
+        nfc_configurable_*;
         nfc_core_*;
         nfc_crc_*;
         nfc_initiator_*;

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -38,6 +38,7 @@ all:
 	@$(MAKE) -C plugins_dbus_service_plugin $*
 	@$(MAKE) -C plugins_dbus_service_tag $*
 	@$(MAKE) -C plugins_dbus_service_util $*
+	@$(MAKE) -C plugins_settings $*
 
 clean: unitclean
 	rm -f *~

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -3,8 +3,9 @@
 all:
 %:
 	@$(MAKE) -C core_adapter $*
-	@$(MAKE) -C core_initiator $*
+	@$(MAKE) -C core_config $*
 	@$(MAKE) -C core_crc $*
+	@$(MAKE) -C core_initiator $*
 	@$(MAKE) -C core_llc $*
 	@$(MAKE) -C core_llc_param $*
 	@$(MAKE) -C core_manager $*

--- a/unit/common/Makefile
+++ b/unit/common/Makefile
@@ -67,7 +67,7 @@ BASE_FLAGS = -fPIC
 BASE_LDFLAGS = $(BASE_FLAGS) $(LDFLAGS)
 BASE_CFLAGS = $(BASE_FLAGS) $(CFLAGS)
 FULL_CFLAGS = $(BASE_CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
-  $(shell pkg-config --cflags $(PKGS))
+  $(shell pkg-config --cflags $(PKGS) $(CFLAGS_PKGS))
 FULL_LDFLAGS = $(BASE_LDFLAGS)
 LIBS = $(shell pkg-config --libs $(PKGS)) -ldl
 DEBUG_FLAGS = -g
@@ -153,7 +153,10 @@ unitclean:
 clean: unitclean
 
 cleaner: unitclean
-	@make -C $(CORE_DIR) clean
+	@$(MAKE) -C "$(CORE_DIR)" clean
+ifneq ($(PLUGINS_DIR),)
+	@$(MAKE) -C "$(PLUGINS_DIR)" clean
+endif
 
 test_banner:
 	@echo "===========" $(EXE) "=========== "

--- a/unit/common/Makefile.plugins
+++ b/unit/common/Makefile.plugins
@@ -9,6 +9,17 @@
 PKGS += gio-2.0
 
 #
+# libdbusaccess is optional
+#
+
+HAVE_DBUSACCESS ?= 1
+
+ifneq ($(HAVE_DBUSACCESS),0)
+CFLAGS_PKGS += libdbusaccess # Don't link with libdbusaccess
+DEFINES += -DHAVE_DBUSACCESS
+endif
+
+#
 # Directories
 #
 

--- a/unit/common/test_common.h
+++ b/unit/common/test_common.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -92,6 +92,10 @@ test_alloc_data(
 GUtilData*
 test_clone_data(
     const GUtilData* data);
+
+int
+test_rmdir(
+    const char* path);
 
 /* Helper macros */
 

--- a/unit/core_config/Makefile
+++ b/unit/core_config/Makefile
@@ -1,0 +1,5 @@
+# -*- Mode: makefile-gmake -*-
+
+EXE = test_core_config
+
+include ../common/Makefile

--- a/unit/core_config/test_core_config.c
+++ b/unit/core_config/test_core_config.c
@@ -1,0 +1,352 @@
+/*
+ * Copyright (C) 2022 Jolla Ltd.
+ * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nfc_plugin_p.h"
+#include "nfc_plugin_impl.h"
+#include "nfc_config.h"
+
+#include "test_common.h"
+
+#include <gutil_strv.h>
+#include <gutil_log.h>
+
+static TestOpt test_opt;
+
+struct nfc_manager {
+    int dummy;
+};
+
+/*==========================================================================*
+ * Test plugin
+ *==========================================================================*/
+
+typedef NfcPluginClass TestPluginClass;
+typedef struct test_plugin {
+    NfcPlugin plugin;
+    NfcManager* manager;
+    gboolean value;
+} TestPlugin;
+
+
+static void test_plugin_configurable_init(NfcConfigurableInterface* iface);
+G_DEFINE_TYPE_WITH_CODE(TestPlugin, test_plugin, NFC_TYPE_PLUGIN,
+G_IMPLEMENT_INTERFACE(NFC_TYPE_CONFIGURABLE, test_plugin_configurable_init))
+#define TEST_TYPE_PLUGIN (test_plugin_get_type())
+#define TEST_PLUGIN(obj) (G_TYPE_CHECK_INSTANCE_CAST(obj, \
+        TEST_TYPE_PLUGIN, TestPlugin))
+#define NFC_PLUGIN_CLASS(klass) G_TYPE_CHECK_CLASS_CAST(klass, \
+        NFC_TYPE_PLUGIN, NfcPluginClass)
+enum test_plugin_signal {
+     TEST_SIGNAL_VALUE_CHANGED,
+     TEST_SIGNAL_COUNT
+};
+#define TEST_SIGNAL_VALUE_CHANGED_NAME "test-value-changed"
+static const char test_plugin_key[] = "key";
+static const char* test_plugin_keys[] = { test_plugin_key, NULL };
+static guint test_plugin_signals[TEST_SIGNAL_COUNT] = { 0 };
+
+TestPlugin*
+test_plugin_new(
+    void)
+{
+    return g_object_new(TEST_TYPE_PLUGIN, NULL);
+}
+
+static
+gboolean
+test_plugin_start(
+    NfcPlugin* plugin,
+    NfcManager* manager)
+{
+    TestPlugin* self = TEST_PLUGIN(plugin);
+
+    g_assert(!self->manager);
+    self->manager = manager;
+    return TRUE;
+}
+
+static
+void
+test_plugin_stop(
+    NfcPlugin* plugin)
+{
+    TestPlugin* self = TEST_PLUGIN(plugin);
+
+    g_assert(self->manager);
+    self->manager = NULL;
+    NFC_PLUGIN_CLASS(test_plugin_parent_class)->stop(plugin);
+}
+
+static
+const char* const*
+test_plugin_configurable_get_keys(
+    NfcConfigurable* conf)
+{
+    return test_plugin_keys;
+}
+
+static
+GVariant*
+test_plugin_configurable_get_value(
+    NfcConfigurable* conf,
+    const char* key)
+{
+    if (!g_strcmp0(test_plugin_key, key)) {
+        /* OK to return a floating reference */
+        return g_variant_new_boolean(TEST_PLUGIN(conf)->value);
+    } else {
+        return NULL;
+    }
+}
+
+static
+gboolean
+test_plugin_configurable_set_value(
+    NfcConfigurable* conf,
+    const char* key,
+    GVariant* value)
+{
+    if (!g_strcmp0(test_plugin_key, key)) {
+        TestPlugin* self = TEST_PLUGIN(conf);
+        const gboolean default_value = FALSE;
+        gboolean changed = FALSE;
+
+        if (value) {
+            gboolean newval = g_variant_get_boolean(value);
+
+            g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_BOOLEAN));
+            if (self->value != newval) {
+                self->value = newval;
+                changed = TRUE;
+            }
+        } else {
+            if (self->value != default_value) {
+                self->value = default_value;
+                changed = TRUE;
+            }
+        }
+        if (changed) {
+            g_signal_emit(self, test_plugin_signals[TEST_SIGNAL_VALUE_CHANGED],
+                g_quark_from_string(key), key, value);
+        }
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static
+gulong
+test_plugin_configurable_add_change_handler(
+    NfcConfigurable* conf,
+    const char* key,
+    NfcConfigChangeFunc func,
+    void* user_data)
+{
+    return g_signal_connect_closure_by_id(TEST_PLUGIN(conf),
+        test_plugin_signals[TEST_SIGNAL_VALUE_CHANGED],
+        key ? g_quark_from_string(key) : 0,
+        g_cclosure_new(G_CALLBACK(func), user_data, NULL), FALSE);
+}
+
+static
+void
+test_plugin_configurable_init(
+    NfcConfigurableInterface* iface)
+{
+    const char* const* keys;
+
+    /* Poke default implementations */
+    g_assert(iface->get_keys);
+    g_assert(iface->get_value);
+    g_assert(iface->set_value);
+    g_assert(iface->add_change_handler);
+    g_assert(iface->remove_handler);
+
+    /* Default implementation ignore the object pointer, pass NULL */
+    keys = iface->get_keys(NULL);
+    g_assert(keys);
+    g_assert(!keys[0]);
+    g_assert(!iface->get_value(NULL, NULL));
+    g_assert(!iface->set_value(NULL, NULL, NULL));
+    g_assert(!iface->add_change_handler(NULL, NULL, NULL, NULL));
+    /* Except for remove_handler() and there's no point of overwriting it */
+
+    iface->get_keys = test_plugin_configurable_get_keys;
+    iface->get_value = test_plugin_configurable_get_value;
+    iface->set_value = test_plugin_configurable_set_value;
+    iface->add_change_handler = test_plugin_configurable_add_change_handler;
+}
+
+static
+void
+test_plugin_init(
+    TestPlugin* self)
+{
+}
+
+static
+void
+test_plugin_class_init(
+    NfcPluginClass* klass)
+{
+    klass->start = test_plugin_start;
+    klass->stop = test_plugin_stop;
+    test_plugin_signals[TEST_SIGNAL_VALUE_CHANGED] =
+        g_signal_new(TEST_SIGNAL_VALUE_CHANGED_NAME, TEST_TYPE_PLUGIN,
+            G_SIGNAL_RUN_FIRST | G_SIGNAL_DETAILED, 0, NULL, NULL, NULL,
+            G_TYPE_NONE, 2, G_TYPE_STRING, G_TYPE_VARIANT);
+}
+
+/*==========================================================================*
+ * null
+ *==========================================================================*/
+
+static
+void
+test_null(
+    void)
+{
+    /* Public interfaces are NULL tolerant */
+    g_assert(!nfc_config_get_keys(NULL));
+    g_assert(!nfc_config_get_value(NULL, NULL));
+    g_assert(!nfc_config_set_value(NULL, NULL, NULL));
+    g_assert(!nfc_config_add_change_handler(NULL, NULL, NULL, NULL));
+    nfc_config_remove_handler(NULL, 0);
+}
+
+/*==========================================================================*
+ * basic
+ *==========================================================================*/
+
+static
+void
+test_basic_cb(
+    NfcConfigurable* conf,
+    const char* key,
+    GVariant* value,
+    void* user_data)
+{
+    int* count = user_data;
+
+    GDEBUG("%s changed", key);
+    g_assert_cmpstr(key, == ,test_plugin_key);
+    (*count)++;
+}
+
+static
+void
+test_basic(
+    void)
+{
+    TestPlugin* test = test_plugin_new();
+    NfcPlugin* plugin = &test->plugin;
+    NfcManager manager = { 0 };
+    NfcConfigurable* conf;
+    GVariant* value;
+    int n = 0;
+    gulong id;
+
+    /* Start */
+    g_assert(nfc_plugin_start(plugin, &manager));
+    g_assert(test->manager == &manager);
+
+    /* Test NfcConfigurable interface */
+    conf = NFC_CONFIGURABLE(plugin);
+    g_assert(conf);
+    g_assert(!nfc_config_get_value(conf, NULL));
+    g_assert(!nfc_config_set_value(conf, NULL, NULL));
+    g_assert(!nfc_config_get_value(conf, "foo"));
+    g_assert(!nfc_config_set_value(conf, "foo", NULL));
+
+    g_assert(gutil_strv_equal((GStrV*)nfc_config_get_keys(conf),
+        (GStrV*)test_plugin_keys));
+
+    g_assert(!nfc_config_add_change_handler(conf, NULL, NULL, NULL));
+    id = nfc_config_add_change_handler(conf, NULL, test_basic_cb, &n);
+    g_assert(id);
+
+    value = nfc_config_get_value(conf, test_plugin_key);
+    g_assert(value);
+    g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_BOOLEAN));
+    g_assert(!g_variant_get_boolean(value));
+    g_variant_unref(value);
+
+    value = g_variant_take_ref(g_variant_new_boolean(TRUE));
+    g_assert(nfc_config_set_value(conf, test_plugin_key, value));
+    g_assert_cmpint(n, == ,1);
+    g_assert(nfc_config_set_value(conf, test_plugin_key, value));
+    g_assert_cmpint(n, == ,1); /* No change => no notification */
+    g_assert(test->value);
+    g_variant_unref(value);
+
+    /* Reset to default */
+    g_assert(nfc_config_set_value(conf, test_plugin_key, NULL));
+    g_assert(!test->value);
+    g_assert_cmpint(n, == ,2);
+
+    nfc_config_remove_handler(conf, 0); /* No effect */
+    nfc_config_remove_handler(conf, id);
+
+    /* Stop */
+    nfc_plugin_stop(plugin);
+    g_assert(!test->manager);
+
+    g_assert(nfc_plugin_ref(plugin) == plugin);
+    nfc_plugin_unref(plugin);
+    nfc_plugin_unref(plugin);
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+#define TEST_(name) "/core/plugin/" name
+
+int main(int argc, char* argv[])
+{
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+    g_type_init();
+    G_GNUC_END_IGNORE_DEPRECATIONS;
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func(TEST_("null"), test_null);
+    g_test_add_func(TEST_("basic"), test_basic);
+    test_init(&test_opt, argc, argv);
+    return g_test_run();
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/coverage/run
+++ b/unit/coverage/run
@@ -5,6 +5,7 @@
 
 TESTS="\
 core_adapter \
+core_config \
 core_crc \
 core_initiator \
 core_llc \

--- a/unit/coverage/run
+++ b/unit/coverage/run
@@ -39,7 +39,8 @@ plugins_dbus_service_adapter \
 plugins_dbus_service_peer \
 plugins_dbus_service_plugin \
 plugins_dbus_service_tag \
-plugins_dbus_service_util"
+plugins_dbus_service_util \
+plugins_settings"
 
 function err() {
     echo "*** ERROR!" $1
@@ -72,7 +73,7 @@ popd > /dev/null
 make -C "$TOP_DIR" clean
 for t in $TESTS ; do
     pushd "$TEST_DIR/$t"
-    make -C "$TEST_DIR/$t" clean coverage || exit 1
+    make -j -C "$TEST_DIR/$t" coverage || exit 1
     build/coverage/test_$t || exit 1
     popd
 done
@@ -85,5 +86,5 @@ rm -f "$CORE_COV" "$PLUGINS_COV" "$ALL_COV" "$FILTERED_COV"
 lcov $LCOV_OPT -c -d "$CORE_DIR/build/coverage" -b "$CORE_DIR" -o "$CORE_COV" || exit 1
 lcov $LCOV_OPT -c -d "$PLUGINS_DIR/build/coverage" -b "$PLUGINS_DIR" -o "$PLUGINS_COV" || exit 1
 lcov $LCOV_OPT -a "$CORE_COV" -a "$PLUGINS_COV" -o "$ALL_COV"
-lcov $LCOV_OPT -e "$ALL_COV" "$CORE_DIR/src/*" "$PLUGINS_DIR/dbus_handlers/*" "$PLUGINS_DIR/dbus_service/*" -o "$FILTERED_COV" || exit 1
+lcov $LCOV_OPT -e "$ALL_COV" "$CORE_DIR/src/*" "$PLUGINS_DIR/dbus_handlers/*" "$PLUGINS_DIR/dbus_service/*" "$PLUGINS_DIR/settings/*" -o "$FILTERED_COV" || exit 1
 genhtml $GENHTML_OPT "$FILTERED_COV" -t "nfcd" --output-directory "$COV_DIR/report" || exit 1

--- a/unit/plugins_settings/Makefile
+++ b/unit/plugins_settings/Makefile
@@ -1,0 +1,9 @@
+# -*- Mode: makefile-gmake -*-
+
+EXE = test_plugins_settings
+
+COMMON_SRC = test_dbus.c test_main.c
+
+EXTRA_EXE_LDFLAGS = -u nfc_core_version
+
+include ../common/Makefile.plugins

--- a/unit/plugins_settings/test_plugins_settings.c
+++ b/unit/plugins_settings/test_plugins_settings.c
@@ -1,0 +1,2260 @@
+/*
+ * Copyright (C) 2022 Jolla Ltd.
+ * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "settings/settings_plugin.h"
+#include "settings/plugin.h"
+#include "internal/nfc_manager_i.h"
+
+#include <nfc_plugin_impl.h>
+#include <nfc_config.h>
+
+#include <glib/gstdio.h>
+
+#ifdef HAVE_DBUSACCESS
+#include <dbusaccess_policy.h>
+#include <dbusaccess_peer.h>
+static DA_ACCESS test_access = DA_ACCESS_ALLOW;
+#define test_allow_calls() (test_access = DA_ACCESS_ALLOW)
+#define test_deny_calls() (test_access = DA_ACCESS_DENY)
+#else
+#define test_allow_calls()
+#define test_deny_calls()
+#endif
+
+#include <gutil_idlepool.h>
+
+#include "test_common.h"
+#include "test_dbus.h"
+
+#define TMP_DIR_TEMPLATE                 "test_XXXXXX"
+#define TEST_PLUGIN_NAME                 "test"
+
+#define SETTINGS_CONFIG_DEFAULTS_FILE    "defaults.conf"
+#define SETTINGS_CONFIG_DEFAULTS_DIR     "defaults.d"
+#define SETTINGS_STORAGE_FILE            "settings"
+#define SETTINGS_STORAGE_DIR_PERM        0700
+#define SETTINGS_GROUP                   "Settings"
+#define SETTINGS_KEY_ENABLED             "Enabled"
+#define SETTINGS_KEY_ALWAYS_ON           "AlwaysOn"
+
+#define SETTINGS_DBUS_PATH               "/"
+#define SETTINGS_DBUS_INTERFACE          "org.sailfishos.nfc.Settings"
+#define SETTINGS_DBUS_INTERFACE_VERSION  (2)
+
+#define SETTINGS_ERROR_(e)               "org.sailfishos.nfc.settings.Error." e
+#define SETTINGS_ERROR_ACCESS_DENIED     SETTINGS_ERROR_("AccessDenied")
+#define SETTINGS_ERROR_UNKNOWN_PLUGIN    SETTINGS_ERROR_("UnknownPlugin")
+#define SETTINGS_ERROR_UNKNOWN_KEY       SETTINGS_ERROR_("UnknownKey")
+#define SETTINGS_ERROR_FAILED            SETTINGS_ERROR_("Failed")
+
+typedef struct test_bus_name {
+    guint id;
+    guint acquire_id;
+    char* name;
+    SettingsPlugin* plugin;
+    GBusAcquiredCallback bus_acquired;
+    GBusNameAcquiredCallback name_acquired;
+    GBusNameLostCallback name_lost;
+} TestBusName;
+
+typedef struct test_data {
+    const char* default_config_dir;
+    const char* default_storage_dir;
+    char* config_dir;
+    char* storage_dir;
+    char* storage_file;
+    GMainLoop* loop;
+    NfcManager* manager;
+    GDBusConnection* client; /* Owned by TestDBus */
+    guint flags;
+} TestData;
+
+typedef
+void
+TestFunc(
+    TestData* test);
+
+static TestOpt test_opt;
+static TestBusName* test_bus_name;
+static GDBusConnection* test_server;
+static SettingsPlugin* test_plugin;
+static GUtilIdlePool* test_pool;
+static const char* dbus_sender = ":1.0";
+
+static NfcPlugin* test_plugin_create(void);
+
+static
+void
+test_data_init_with_plugins(
+    TestData* test,
+    const char* config,
+    TestFunc prestart,
+    const NfcPluginDesc* const plugins[])
+{
+    NfcPluginsInfo pi;
+    SettingsPluginClass* klass = g_type_class_ref(SETTINGS_PLUGIN_TYPE);
+
+    memset(test, 0, sizeof(*test));
+    memset(&pi, 0, sizeof(pi));
+
+    g_assert(klass);
+    test->config_dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    test->storage_dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    test->storage_file = g_build_filename(test->storage_dir,
+        SETTINGS_STORAGE_FILE, NULL);
+    test->default_config_dir = klass->config_dir;
+    test->default_storage_dir = klass->storage_dir;
+    klass->config_dir = test->config_dir;
+    klass->storage_dir = test->storage_dir;
+    g_type_class_unref(klass);
+
+    if (config) {
+        GDEBUG("%s\n%s", test->storage_file, config);
+        g_assert(g_file_set_contents(test->storage_file, config, -1, NULL));
+    }
+
+    if (prestart) {
+        prestart(test);
+    }
+
+    pi.builtins = plugins;
+    g_assert((test->manager = nfc_manager_new(&pi)) != NULL);
+    test->loop = g_main_loop_new(NULL, TRUE);
+    test_pool = gutil_idle_pool_new();
+}
+
+static
+void
+test_data_init3(
+    TestData* test,
+    const char* config,
+    TestFunc prestart)
+{
+    static const NfcPluginDesc NFC_PLUGIN_DESC(test) = {
+        TEST_PLUGIN_NAME, "Test", NFC_CORE_VERSION,
+        test_plugin_create, NULL, 0
+    };
+
+    static const NfcPluginDesc* const test_plugins2[] = {
+        &NFC_PLUGIN_DESC(settings),
+        &NFC_PLUGIN_DESC(test),
+        NULL
+    };
+
+    test_data_init_with_plugins(test, config, prestart, test_plugins2);
+}
+
+static
+void
+test_data_init2(
+    TestData* test,
+    const char* config)
+{
+    test_data_init3(test, config, NULL);
+}
+
+static
+void
+test_data_init(
+    TestData* test,
+    const char* config)
+{
+    static const NfcPluginDesc* const test_plugins[] = {
+        &NFC_PLUGIN_DESC(settings),
+        NULL
+    };
+
+    test_data_init_with_plugins(test, config, NULL, test_plugins);
+}
+
+static
+void
+test_data_cleanup(
+    TestData* test)
+{
+    SettingsPluginClass* klass = g_type_class_ref(SETTINGS_PLUGIN_TYPE);
+    char* config = NULL;
+
+    klass->config_dir = test->default_config_dir;
+    klass->storage_dir = test->default_storage_dir;
+    g_type_class_unref(klass);
+
+    test_server = NULL;
+    gutil_idle_pool_destroy(test_pool);
+    test_pool = NULL;
+    nfc_manager_stop(test->manager, 0);
+    nfc_manager_unref(test->manager);
+    g_main_loop_unref(test->loop);
+
+    /* Dump the config file if it's present */
+    if (g_file_get_contents(test->storage_file, &config, NULL, NULL)) {
+        GDEBUG("%s\n%s", test->storage_file, config);
+        g_free(config);
+    }
+
+    /* And delete the temporary files */
+    g_assert_cmpint(test_rmdir(test->config_dir), == ,0);
+    g_assert_cmpint(test_rmdir(test->storage_dir), == ,0);
+    g_free(test->storage_file);
+    g_free(test->storage_dir);
+    g_free(test->config_dir);
+    memset(test, 0, sizeof(*test));
+}
+
+static
+void
+test_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* user_data)
+{
+    TestData* test = user_data;
+
+    test_server = server;
+    g_assert(nfc_manager_start(test->manager));
+}
+
+static
+void
+test_dbus_call(
+    TestData* test,
+    GDBusConnection* client,
+    const char* method,
+    GVariant* parameters,
+    GAsyncReadyCallback callback)
+{
+    g_dbus_connection_call(client, NULL, SETTINGS_DBUS_PATH,
+        SETTINGS_DBUS_INTERFACE, method, parameters, NULL,
+        G_DBUS_CALL_FLAGS_NONE, -1, NULL, callback, test);
+}
+
+static
+void
+test_call(
+    TestData* test,
+    GDBusConnection* client,
+    const char* method,
+    GAsyncReadyCallback callback)
+{
+    test_dbus_call(test, client, method, NULL, callback);
+}
+
+static
+void
+test_call_set_enabled(
+    TestData* test,
+    GDBusConnection* client,
+    gboolean enabled,
+    GAsyncReadyCallback callback)
+{
+    test_dbus_call(test, client, "SetEnabled",
+        g_variant_new("(b)", enabled), callback);
+}
+
+static
+void
+test_call_get_plugin_settings(
+    TestData* test,
+    GDBusConnection* client,
+    const char* plugin,
+    GAsyncReadyCallback callback)
+{
+    test_dbus_call(test, client, "GetPluginSettings",
+        g_variant_new("(s)", plugin), callback);
+}
+
+static
+void
+test_call_get_plugin_value(
+    TestData* test,
+    GDBusConnection* client,
+    const char* plugin,
+    const char* key,
+    GAsyncReadyCallback callback)
+{
+    test_dbus_call(test, client, "GetPluginValue",
+        g_variant_new("(ss)", plugin, key), callback);
+}
+
+static
+void
+test_call_set_plugin_value(
+    TestData* test,
+    GDBusConnection* client,
+    const char* plugin,
+    const char* key,
+    GVariant* value,
+    GAsyncReadyCallback callback)
+{
+    test_dbus_call(test, client, "SetPluginValue",
+        g_variant_new("(ss@v)", plugin, key, value), callback);
+}
+
+static
+void
+test_done_with_error(
+    GObject* object,
+    GAsyncResult* result,
+    TestData* test,
+    const char* expected_error)
+{
+    GError* error = NULL;
+    char* remote_error;
+
+    g_assert(!g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error));
+    g_assert(error);
+    g_assert(g_dbus_error_is_remote_error(error));
+    remote_error = g_dbus_error_get_remote_error(error);
+    GDEBUG("%s", remote_error);
+    g_assert_cmpstr(remote_error, == ,expected_error);
+    g_error_free(error);
+    g_free(remote_error);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_done_access_denied(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    test_done_with_error(object, result, (TestData*) user_data,
+        SETTINGS_ERROR_ACCESS_DENIED);
+}
+
+static
+void
+test_get_plugin_value_check(
+    GDBusConnection* client,
+    GAsyncResult* result,
+    TestData* test,
+    const char* expected_value)
+{
+    GError* error = NULL;
+    GVariant* value = NULL;
+    GVariant* string = NULL;
+    GVariant* var = g_dbus_connection_call_finish(client, result, &error);
+
+    g_assert(!error);
+    g_assert(var);
+    g_variant_get(var, "(@v)", &value);
+    g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_VARIANT));
+    string = g_variant_get_variant(value);
+    g_assert(g_variant_is_of_type(string, G_VARIANT_TYPE_STRING));
+    GDEBUG("%s", g_variant_get_string(string, NULL));
+    g_assert_cmpstr(g_variant_get_string(string, NULL), == ,expected_value);
+
+    g_variant_unref(value);
+    g_variant_unref(string);
+    g_variant_unref(var);
+}
+
+static
+void
+test_get_plugin_value_done(
+    GObject* client,
+    GAsyncResult* result,
+    TestData* test,
+    const char* val)
+{
+    test_get_plugin_value_check(G_DBUS_CONNECTION(client), result, test, val);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_call_ok_check(
+    GDBusConnection* client,
+    GAsyncResult* result)
+{
+    GError* error = NULL;
+    GVariant* var = g_dbus_connection_call_finish(client, result, &error);
+
+    g_assert(!error);
+    g_assert(var);
+    g_variant_unref(var);
+}
+
+static
+void
+test_call_ok_done(
+    GObject* client,
+    GAsyncResult* result,
+    TestData* test)
+{
+    test_call_ok_check(G_DBUS_CONNECTION(client), result);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_access_denied(
+    TestDBusStartFunc start)
+{
+    TestData test;
+    TestDBus* dbus;
+
+    test_deny_calls();
+    test_data_init(&test, NULL);
+    dbus = test_dbus_new2(test_start, start, &test);
+    test_run(&test_opt, test.loop);
+    test_data_cleanup(&test);
+    test_dbus_free(dbus);
+}
+
+static
+void
+test_done_unknown_plugin(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    test_done_with_error(object, result, (TestData*) user_data,
+        SETTINGS_ERROR_UNKNOWN_PLUGIN);
+}
+
+static
+void
+test_done_unknown_key(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    test_done_with_error(object, result, (TestData*) user_data,
+        SETTINGS_ERROR_UNKNOWN_KEY);
+}
+
+static
+void
+test_done_failed(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    test_done_with_error(object, result, (TestData*) user_data,
+        SETTINGS_ERROR_FAILED);
+}
+
+static
+void
+test_normal_run(
+    void (*init)(TestData* test, const char* config),
+    const char* config,
+    TestDBusStartFunc start)
+{
+    TestData test;
+    TestDBus* dbus;
+
+    test_allow_calls();
+    init(&test, config);
+    dbus = test_dbus_new2(test_start, start, &test);
+    test_run(&test_opt, test.loop);
+    test_data_cleanup(&test);
+    test_dbus_free(dbus);
+}
+
+static
+void
+test_normal(
+    TestDBusStartFunc start)
+{
+    test_normal_run(test_data_init, NULL, start);
+}
+
+static
+void
+test_normal2(
+    const char* config,
+    TestDBusStartFunc start)
+{
+    test_normal_run(test_data_init2, config, start);
+}
+
+static
+void
+test_normal3(
+    const char* config,
+    TestFunc prestart,
+    TestDBusStartFunc start)
+{
+    TestData test;
+    TestDBus* dbus;
+
+    test_allow_calls();
+    test_data_init3(&test, config, prestart);
+    dbus = test_dbus_new2(test_start, start, &test);
+    test_run(&test_opt, test.loop);
+    test_data_cleanup(&test);
+    test_dbus_free(dbus);
+}
+
+/*==========================================================================*
+ * Test plugin
+ *==========================================================================*/
+
+typedef NfcPluginClass TestPluginClass;
+typedef struct test_plugin {
+    NfcPlugin plugin;
+    NfcManager* manager;
+    char* value;
+} TestPlugin;
+
+#define TEST_PLUGIN_KEY "key"
+#define TEST_PLUGIN_DEFAULT_VALUE "value"
+#define TEST_PLUGIN_NON_DEFAULT_VALUE "non-default"
+static void test_plugin_config_init(NfcConfigurableInterface* iface);
+G_DEFINE_TYPE_WITH_CODE(TestPlugin, test_plugin, NFC_TYPE_PLUGIN,
+G_IMPLEMENT_INTERFACE(NFC_TYPE_CONFIGURABLE, test_plugin_config_init))
+#define TEST_TYPE_PLUGIN (test_plugin_get_type())
+#define TEST_PLUGIN(obj) (G_TYPE_CHECK_INSTANCE_CAST(obj, \
+        TEST_TYPE_PLUGIN, TestPlugin))
+#define PARENT_CLASS() G_TYPE_CHECK_CLASS_CAST(test_plugin_parent_class, \
+        NFC_TYPE_PLUGIN, NfcPluginClass)
+#define TEST_CONFIG_VALUE_CHANGED_NAME "test-plugin-config-value-changed"
+enum neard_plugin_signal {
+     TEST_CONFIG_VALUE_CHANGED,
+     TEST_PLUGIN_SIGNAL_COUNT
+};
+static guint test_plugin_signals[TEST_PLUGIN_SIGNAL_COUNT] = { 0 };
+
+static
+NfcPlugin*
+test_plugin_create(
+    void)
+{
+    return g_object_new(TEST_TYPE_PLUGIN, NULL);
+}
+
+static
+gboolean
+test_plugin_start(
+    NfcPlugin* plugin,
+    NfcManager* manager)
+{
+    TestPlugin* self = TEST_PLUGIN(plugin);
+
+    g_assert(!self->manager);
+    self->manager = manager;
+    return TRUE;
+}
+
+static
+void
+test_plugin_stop(
+    NfcPlugin* plugin)
+{
+    TestPlugin* self = TEST_PLUGIN(plugin);
+
+    g_assert(self->manager);
+    self->manager = NULL;
+    PARENT_CLASS()->stop(plugin);
+}
+
+static
+void
+test_plugin_init(
+    TestPlugin* self)
+{
+    self->value = g_strdup(TEST_PLUGIN_DEFAULT_VALUE);
+}
+
+static
+void
+test_plugin_finalize(
+    GObject* plugin)
+{
+    TestPlugin* self = TEST_PLUGIN(plugin);
+
+    g_free(self->value);
+    G_OBJECT_CLASS(test_plugin_parent_class)->finalize(plugin);
+}
+
+static
+void
+test_plugin_class_init(
+    NfcPluginClass* klass)
+{
+    G_OBJECT_CLASS(klass)->finalize = test_plugin_finalize;
+    klass->start = test_plugin_start;
+    klass->stop = test_plugin_stop;
+    test_plugin_signals[TEST_CONFIG_VALUE_CHANGED] =
+        g_signal_new(TEST_CONFIG_VALUE_CHANGED_NAME,
+            G_OBJECT_CLASS_TYPE(klass), G_SIGNAL_RUN_FIRST |
+            G_SIGNAL_DETAILED, 0, NULL, NULL, NULL,
+            G_TYPE_NONE, 2, G_TYPE_STRING, G_TYPE_VARIANT);
+}
+
+static
+const char* const*
+test_plugin_config_get_keys(
+    NfcConfigurable* config)
+{
+    static const char* const test_plugin_keys[] = {
+        TEST_PLUGIN_KEY, NULL
+    };
+
+    return test_plugin_keys;
+}
+
+static
+GVariant*
+test_plugin_config_get_value(
+    NfcConfigurable* config,
+    const char* key)
+{
+    TestPlugin* self = TEST_PLUGIN(config);
+
+    if (!g_strcmp0(key, TEST_PLUGIN_KEY)) {
+        /* OK to return a floating reference */
+        return g_variant_new_string(self->value);
+    } else {
+        return NULL;
+    }
+}
+
+static
+gboolean
+test_plugin_config_set_value(
+    NfcConfigurable* config,
+    const char* key,
+    GVariant* value)
+{
+    TestPlugin* self = TEST_PLUGIN(config);
+    gboolean ok = FALSE;
+
+    if (!g_strcmp0(key, TEST_PLUGIN_KEY)) {
+        const char* newval = TEST_PLUGIN_DEFAULT_VALUE;
+
+        if (!value) {
+            ok = TRUE;
+        } else if (g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
+            newval = g_variant_get_string(value, NULL);
+            ok = TRUE;
+        }
+
+        if (ok && g_strcmp0(self->value, newval)) {
+            GDEBUG("%s: %s => %s", key, self->value, newval);
+            g_free(self->value);
+            self->value = g_strdup(newval);
+            g_signal_emit(self, test_plugin_signals
+                [TEST_CONFIG_VALUE_CHANGED], g_quark_from_string(key),
+                key, value);
+        }
+    }
+    return ok;
+}
+
+static
+gulong
+test_plugin_config_add_change_handler(
+    NfcConfigurable* config,
+    const char* key,
+    NfcConfigChangeFunc func,
+    void* user_data)
+{
+    return g_signal_connect_closure_by_id(TEST_PLUGIN(config),
+        test_plugin_signals[TEST_CONFIG_VALUE_CHANGED],
+        key ? g_quark_from_string(key) : 0,
+        g_cclosure_new(G_CALLBACK(func), user_data, NULL), FALSE);
+}
+
+static
+void
+test_plugin_config_init(
+    NfcConfigurableInterface* iface)
+{
+    iface->get_keys = test_plugin_config_get_keys;
+    iface->get_value = test_plugin_config_get_value;
+    iface->set_value = test_plugin_config_set_value;
+    iface->add_change_handler = test_plugin_config_add_change_handler;
+}
+
+/*==========================================================================*
+ * Stubs
+ *==========================================================================*/
+
+#define TEST_NAME_OWN_ID (1)
+#define TEST_NAME_WATCH_ID (2)
+
+static
+gboolean
+test_bus_acquired(
+    gpointer user_data)
+{
+    TestBusName* data = user_data;
+
+    g_assert(test_server);
+    data->acquire_id = 0;
+    data->bus_acquired(test_server, data->name, data->plugin);
+    data->name_acquired(test_server, data->name, data->plugin);
+    return G_SOURCE_REMOVE;
+}
+
+guint
+settings_plugin_name_own(
+    SettingsPlugin* plugin,
+    const char* name,
+    GBusAcquiredCallback bus_acquired,
+    GBusNameAcquiredCallback name_acquired,
+    GBusNameLostCallback name_lost)
+{
+    TestBusName* data = g_new(TestBusName, 1);
+
+    data->plugin = test_plugin = plugin;
+    data->id = TEST_NAME_OWN_ID;
+    data->name = g_strdup(name);
+    data->bus_acquired = bus_acquired;
+    data->name_acquired = name_acquired;
+    data->name_lost = name_lost;
+    data->acquire_id = g_idle_add_full(G_PRIORITY_HIGH_IDLE,
+        test_bus_acquired, data, NULL);
+
+    g_assert(!test_bus_name); /* Only one is expected */
+    test_bus_name = data;
+    return data->id;
+}
+
+void
+settings_plugin_name_unown(
+    guint id)
+{
+    TestBusName* data = test_bus_name;
+
+    g_assert(test_plugin);
+    g_assert(test_bus_name);
+
+    g_assert(data->plugin == test_plugin);
+    g_assert_cmpint(data->id, == ,id);
+    if (data->acquire_id) {
+        g_source_remove(data->acquire_id);
+    }
+    g_free(data->name);
+    g_free(data);
+
+    test_bus_name = NULL;
+}
+
+const gchar*
+g_dbus_method_invocation_get_sender(
+    GDBusMethodInvocation* call)
+{
+    return dbus_sender;
+}
+
+guint
+g_bus_watch_name_on_connection(
+    GDBusConnection* connection,
+    const gchar* name,
+    GBusNameWatcherFlags flags,
+    GBusNameAppearedCallback name_appeared_handler,
+    GBusNameVanishedCallback name_vanished_handler,
+    gpointer user_data,
+    GDestroyNotify user_data_free_func)
+{
+    g_assert_cmpstr(name, == ,dbus_sender);
+    return TEST_NAME_WATCH_ID;
+}
+
+void
+g_bus_unwatch_name(
+    guint watcher_id)
+{
+    g_assert_cmpuint(watcher_id, == ,TEST_NAME_WATCH_ID);
+}
+
+#ifdef HAVE_DBUSACCESS
+
+struct da_policy {
+    gint refcount;
+};
+
+DAPeer*
+da_peer_get(
+    DA_BUS bus,
+    const char* name)
+{
+    gsize name_len = strlen(name);
+    DAPeer* peer = g_malloc0(sizeof(DAPeer) + name_len + 1);
+    char* name_copy = (char*)(peer + 1);
+
+    memcpy(name_copy, name, name_len);
+    peer->name = name_copy;
+    gutil_idle_pool_add(test_pool, peer, g_free);
+    return peer;
+}
+
+DAPolicy*
+da_policy_new_full(
+    const char* spec,
+    const DA_ACTION* actions)
+{
+    DAPolicy* policy = g_new0(DAPolicy, 1);
+
+    g_atomic_int_set(&policy->refcount, 1);
+    return policy;
+}
+
+void
+da_policy_unref(
+    DAPolicy* policy)
+{
+    if (policy && g_atomic_int_dec_and_test(&policy->refcount)) {
+        g_free(policy);
+    }
+}
+
+DA_ACCESS
+da_policy_check(
+    const DAPolicy* policy,
+    const DACred* cred,
+    guint action,
+    const char* arg,
+    DA_ACCESS def)
+{
+    GDEBUG("%s action %u", (test_access == DA_ACCESS_ALLOW) ?
+        "Allowing" : "Not allowing", action);
+    return test_access;
+}
+
+#endif /* HAVE_DBUSACCESS */
+
+/*==========================================================================*
+ * name_lost
+ *==========================================================================*/
+
+static
+void
+test_name_lost_done(
+    NfcManager* manager,
+    void* user_data)
+{
+    TestData* test = user_data;
+
+    GDEBUG("Done");
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_name_lost_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test_data)
+{
+    TestData* test = test_data;
+    TestBusName* name = test_bus_name;
+    gulong id = nfc_manager_add_stopped_handler(test->manager,
+        test_name_lost_done, test);
+
+    g_assert(test_bus_name);
+    g_assert(test_server);
+    name->name_lost(test_server, name->name, name->plugin);
+
+    /* test_name_lost_done() is already invoked by now */
+    nfc_manager_remove_handler(test->manager, id);
+}
+
+static
+void
+test_name_lost(
+    void)
+{
+    test_normal(test_name_lost_start);
+}
+
+/*==========================================================================*
+ * defaults/load
+ *==========================================================================*/
+
+static
+void
+test_defaults_load_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    test_get_plugin_value_done(object, result, user_data, "foo");
+}
+
+static
+void
+test_defaults_load_changed(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GError* error = NULL;
+    GKeyFile* conf = g_key_file_new();
+    GDBusConnection* client = G_DBUS_CONNECTION(object);
+    GVariant* var = g_dbus_connection_call_finish(client, result, &error);
+
+    g_assert(test->manager->enabled);
+    g_assert(var);
+    g_assert(!error);
+    g_variant_unref(var);
+
+    /* Make sure the new value is saved */
+    g_assert(g_key_file_load_from_file(conf, test->storage_file, 0, NULL));
+    g_assert(g_key_file_get_boolean(conf, SETTINGS_GROUP, SETTINGS_KEY_ENABLED,
+        NULL));
+    g_key_file_unref(conf);
+
+    /* And query the plugin's value */
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        test_defaults_load_done);
+}
+
+static
+void
+test_defaults_load_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* user_data)
+{
+    TestData* test = user_data;
+
+    /* Verify that defaults have been applied */
+    g_assert(!test->manager->enabled);
+
+    /* Enable it */
+    test_call_set_enabled(test, client, TRUE, test_defaults_load_changed);
+}
+
+static
+void
+test_defaults_load_prestart(
+    TestData* test)
+{
+    char* defaults_file = g_build_filename(test->config_dir,
+        SETTINGS_CONFIG_DEFAULTS_FILE, NULL);
+    char* override_dir = g_build_filename(test->config_dir,
+        SETTINGS_CONFIG_DEFAULTS_DIR, NULL);
+    static const char defaults[] =
+        "[" SETTINGS_GROUP "]\n"
+        SETTINGS_KEY_ENABLED "=false\n"
+        "[" TEST_PLUGIN_NAME "]\n"
+        TEST_PLUGIN_KEY "='foo'\n";
+
+    /* Create empty override directory */
+    g_assert_cmpint(g_mkdir(override_dir, SETTINGS_STORAGE_DIR_PERM), == ,0);
+
+    /* Write the defaults file */
+    GDEBUG("%s\n%s", defaults_file, defaults);
+    g_assert(g_file_set_contents(defaults_file, defaults, -1, NULL));
+
+    g_free(defaults_file);
+    g_free(override_dir);
+}
+
+static
+void
+test_defaults_load(
+    void)
+{
+    test_normal3(NULL, test_defaults_load_prestart,
+        test_defaults_load_start);
+}
+
+/*==========================================================================*
+ * defaults/override
+ *==========================================================================*/
+
+static
+void
+test_defaults_override_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+
+    /* Since all values are default, there was need to save the settings */
+    g_assert(!g_file_test(test->storage_file, G_FILE_TEST_EXISTS));
+    test_get_plugin_value_done(object, result, test, "bar");
+}
+
+static
+void
+test_defaults_override_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* user_data)
+{
+    TestData* test = user_data;
+
+    /* Verify the state */
+    g_assert(test->manager->enabled);
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        test_defaults_override_done);
+}
+
+static
+void
+test_defaults_override_prestart(
+    TestData* test)
+{
+    char* defaults_file = g_build_filename(test->config_dir,
+        SETTINGS_CONFIG_DEFAULTS_FILE, NULL);
+    char* override_dir = g_build_filename(test->config_dir,
+        SETTINGS_CONFIG_DEFAULTS_DIR, NULL);
+    char* override_file = g_build_filename(override_dir, "override", NULL);
+    static const char defaults[] =
+        "[" SETTINGS_GROUP "]\n"
+        SETTINGS_KEY_ENABLED "=false\n"
+        "[" TEST_PLUGIN_NAME "]\n"
+        TEST_PLUGIN_KEY "='foo'\n"
+        "invalid-key=false\n";
+    static const char override[] =
+        "[" SETTINGS_GROUP "]\n"
+        SETTINGS_KEY_ENABLED "=true\n"
+        "[" TEST_PLUGIN_NAME "]\n"
+        TEST_PLUGIN_KEY "='bar'\n"
+        "[whatever]\n"
+        "something=false\n";
+
+    GDEBUG("%s\n%s", defaults_file, defaults);
+    GDEBUG("%s\n%s", override_file, override);
+    g_assert_cmpint(g_mkdir(override_dir, SETTINGS_STORAGE_DIR_PERM), == ,0);
+    g_assert(g_file_set_contents(defaults_file, defaults, -1, NULL));
+    g_assert(g_file_set_contents(override_file, override, -1, NULL));
+
+    g_free(defaults_file);
+    g_free(override_dir);
+    g_free(override_file);
+}
+
+static
+void
+test_defaults_override(
+    void)
+{
+    test_normal3(NULL, test_defaults_override_prestart,
+        test_defaults_override_start);
+}
+
+/*==========================================================================*
+ * defaults/no_override
+ *==========================================================================*/
+
+static
+void
+test_defaults_no_override_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+
+    /* Since all values are default, there was need to save the settings */
+    g_assert(!g_file_test(test->storage_file, G_FILE_TEST_EXISTS));
+    test_get_plugin_value_done(object, result, test, "foo");
+}
+
+static
+void
+test_defaults_no_override_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* user_data)
+{
+    TestData* test = user_data;
+
+    /* Verify the state */
+    g_assert(!test->manager->enabled);
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        test_defaults_no_override_done);
+}
+
+static
+void
+test_defaults_no_override_prestart(
+    TestData* test)
+{
+    char* defaults_file = g_build_filename(test->config_dir,
+        SETTINGS_CONFIG_DEFAULTS_FILE, NULL);
+    char* override_dir = g_build_filename(test->config_dir,
+        SETTINGS_CONFIG_DEFAULTS_DIR, NULL);
+    char* override_file = g_build_filename(override_dir, "override", NULL);
+    char* rogue_file = g_build_filename(override_dir, "junkfile", NULL);
+    char* rogue_dir = g_build_filename(override_dir, "junkdir", NULL);
+    static const char defaults[] =
+        "[" SETTINGS_GROUP "]\n"
+        SETTINGS_KEY_ENABLED "=false\n"
+        "[" TEST_PLUGIN_NAME "]\n"
+        TEST_PLUGIN_KEY "='foo'\n";
+    static const char override[] =
+        "[" SETTINGS_GROUP "]\n"
+        "invalid-key=false\n"
+        "[" TEST_PLUGIN_NAME "]\n"
+        "invalid-key=false\n";
+
+    GDEBUG("%s\n%s", defaults_file, defaults);
+    GDEBUG("%s\n%s", override_file, override);
+    g_assert_cmpint(g_mkdir(override_dir, SETTINGS_STORAGE_DIR_PERM), == ,0);
+    g_assert_cmpint(g_mkdir(rogue_dir, SETTINGS_STORAGE_DIR_PERM), == ,0);
+    g_assert(g_file_set_contents(defaults_file, defaults, -1, NULL));
+    g_assert(g_file_set_contents(override_file, override, -1, NULL));
+    g_assert(g_file_set_contents(rogue_file, "junk", -1, NULL));
+
+    g_free(defaults_file);
+    g_free(override_dir);
+    g_free(override_file);
+    g_free(rogue_file);
+    g_free(rogue_dir);
+}
+
+static
+void
+test_defaults_no_override(
+    void)
+{
+    test_normal3(NULL, test_defaults_no_override_prestart,
+        test_defaults_no_override_start);
+}
+
+/*==========================================================================*
+ * config/load
+ *==========================================================================*/
+
+static
+void
+test_config_load_done(
+    GObject* client,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GKeyFile* config = g_key_file_new();
+
+    test_call_ok_done(client, result, test);
+
+    /*
+     * The config file is there but the value has been removed because
+     * it now matches the default.
+     */
+    g_assert(g_key_file_load_from_file(config, test->storage_file, 0, NULL));
+    g_assert(!g_key_file_get_value(config, TEST_PLUGIN_NAME,
+        TEST_PLUGIN_KEY, NULL));
+    g_assert(!g_key_file_get_value(config, SETTINGS_GROUP,
+        SETTINGS_KEY_ENABLED, NULL));
+    g_key_file_unref(config);
+}
+
+static
+void
+test_config_load_enabled(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GDBusConnection* client = G_DBUS_CONNECTION(object);
+
+    test_call_ok_check(client, result);
+    g_assert(test->manager->enabled);
+
+    /* Set the plugin value matching the default loaded from the file */
+    test_call_set_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        g_variant_new_variant(g_variant_new_string("bar")),
+        test_config_load_done);
+}
+
+static
+void
+test_config_load_check(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GDBusConnection* client = G_DBUS_CONNECTION(object);
+
+    /* Value is taken from the config */
+    test_get_plugin_value_check(client, result, user_data, "foo");
+
+    /* Set Enabled value that matches the default loaded from the file */
+    test_call_set_enabled(test, client, TRUE, test_config_load_enabled);
+}
+
+static
+void
+test_config_load_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* user_data)
+{
+    TestData* test = user_data;
+
+    g_assert(!test->manager->enabled);
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        test_config_load_check);
+}
+
+static
+void
+test_config_load_prestart(
+    TestData* test)
+{
+    char* defaults_file = g_build_filename(test->config_dir,
+        SETTINGS_CONFIG_DEFAULTS_FILE, NULL);
+    static const char defaults[] =
+        "[" SETTINGS_GROUP "]\n"
+        SETTINGS_KEY_ENABLED "=true\n"
+        "[" TEST_PLUGIN_NAME "]\n"
+        TEST_PLUGIN_KEY "='bar'\n";
+
+    GDEBUG("%s\n%s", defaults_file, defaults);
+    g_assert(g_file_set_contents(defaults_file, defaults, -1, NULL));
+    g_free(defaults_file);
+}
+
+static
+void
+test_config_load(
+    void)
+{
+    test_normal3("[" SETTINGS_GROUP "]\n"
+        SETTINGS_KEY_ENABLED "=false\n"
+        "[" TEST_PLUGIN_NAME "]\n"
+        TEST_PLUGIN_KEY "='foo'\n",
+        test_config_load_prestart, test_config_load_start);
+}
+
+/*==========================================================================*
+ * get_all/ok
+ *==========================================================================*/
+
+static
+void
+test_get_all_ok_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    gint version = 0;
+    gboolean enabled = FALSE;
+    GError* error = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error);
+
+    g_assert(var);
+    g_assert(!error);
+    g_variant_get(var, "(ib)", &version, &enabled);
+    GDEBUG("version=%d, enabled=%d", version, enabled);
+    g_assert_cmpint(version, >= ,SETTINGS_DBUS_INTERFACE_VERSION);
+    g_assert(enabled);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_all_ok_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetAll", test_get_all_ok_done);
+}
+
+static
+void
+test_get_all_ok(
+    void)
+{
+    test_normal(test_get_all_ok_start);
+}
+
+/*==========================================================================*
+ * get_all/access_denied
+ *==========================================================================*/
+
+static
+void
+test_get_all_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetAll", test_done_access_denied);
+}
+
+static
+void
+test_get_all_access_denied(
+    void)
+{
+    test_access_denied(test_get_all_access_denied_start);
+}
+
+/*==========================================================================*
+ * get_interface_version/ok
+ *==========================================================================*/
+
+static
+void
+test_get_interface_version_ok_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    gint version = 0;
+    GError* error = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error);
+
+    g_assert(var);
+    g_assert(!error);
+    g_variant_get(var, "(i)", &version);
+    GDEBUG("version=%d", version);
+    g_assert_cmpint(version, >= ,SETTINGS_DBUS_INTERFACE_VERSION);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_interface_version_ok_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetInterfaceVersion",
+        test_get_interface_version_ok_done);
+}
+
+static
+void
+test_get_interface_version_ok(
+    void)
+{
+    test_normal(test_get_interface_version_ok_start);
+}
+
+/*==========================================================================*
+ * get_interface_version/access_denied
+ *==========================================================================*/
+
+static
+void
+test_get_interface_version_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetInterfaceVersion", test_done_access_denied);
+}
+
+static
+void
+test_get_interface_version_access_denied(
+    void)
+{
+    test_access_denied(test_get_interface_version_access_denied_start);
+}
+
+/*==========================================================================*
+ * get_enabled/ok
+ *==========================================================================*/
+
+static
+void
+test_get_enabled_ok_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    gboolean enabled = 0;
+    GError* error = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error);
+
+    g_assert(var);
+    g_assert(!error);
+    g_variant_get(var, "(b)", &enabled);
+    GDEBUG("enabled=%d", enabled);
+    g_assert(enabled);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_enabled_ok_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetEnabled", test_get_enabled_ok_done);
+}
+
+static
+void
+test_get_enabled_ok(
+    void)
+{
+    test_normal(test_get_enabled_ok_start);
+}
+
+/*==========================================================================*
+ * get_enabled/access_denied
+ *==========================================================================*/
+
+static
+void
+test_get_enabled_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetEnabled", test_done_access_denied);
+}
+
+static
+void
+test_get_enabled_access_denied(
+    void)
+{
+    test_access_denied(test_get_enabled_access_denied_start);
+}
+
+/*==========================================================================*
+ * set_enabled/ok
+ *==========================================================================*/
+
+static
+void
+test_set_enabled_ok_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GError* error = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error);
+
+    g_assert(!test->manager->enabled);
+    g_assert(var);
+    g_assert(!error);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_set_enabled_ok_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* user_data)
+{
+    TestData* test = user_data;
+
+    g_assert(test->manager->enabled);
+    test_call_set_enabled(test, client, FALSE, test_set_enabled_ok_done);
+}
+
+static
+void
+test_set_enabled_ok(
+    void)
+{
+    test_normal(test_set_enabled_ok_start);
+}
+
+/*==========================================================================*
+ * set_enabled/access_denied
+ *==========================================================================*/
+
+static
+void
+test_set_enabled_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_set_enabled(test, client, TRUE, test_done_access_denied);
+}
+
+static
+void
+test_set_enabled_access_denied(
+    void)
+{
+    test_access_denied(test_set_enabled_access_denied_start);
+}
+
+/*==========================================================================*
+ * get_all2/ok
+ *==========================================================================*/
+
+static
+void
+test_get_all2_ok_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GError* error = NULL;
+    gint version = 0;
+    gboolean enabled = FALSE;
+    GVariant* settings = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error);
+
+    g_assert(var);
+    g_assert(!error);
+    g_variant_get(var, "(ib@a(sa{sv}))", &version, &enabled, &settings);
+    GDEBUG("version=%d, enabled=%d, %d plugins", version, enabled, (int)
+        g_variant_n_children(settings));
+    g_assert_cmpint(version, >= ,SETTINGS_DBUS_INTERFACE_VERSION);
+    g_assert(enabled);
+    g_assert(g_variant_is_container(settings));
+    g_assert_cmpint(g_variant_n_children(settings), == ,0);
+    g_variant_unref(settings);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_all2_ok_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetAll2", test_get_all2_ok_done);
+}
+
+static
+void
+test_get_all2_ok(
+    void)
+{
+    test_normal(test_get_all2_ok_start);
+}
+
+/*==========================================================================*
+ * get_all2/access_denied
+ *==========================================================================*/
+
+static
+void
+test_get_all2_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetAll2", test_done_access_denied);
+}
+
+static
+void
+test_get_all2_access_denied(
+    void)
+{
+    test_access_denied(test_get_all2_access_denied_start);
+}
+
+/*==========================================================================*
+ * get_all_plugin_settings/empty
+ *==========================================================================*/
+
+static
+void
+test_get_all_plugin_settings_empty_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GError* error = NULL;
+    GVariant* settings = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error);
+
+    g_assert(var);
+    g_assert(!error);
+    g_variant_get(var, "(@a(sa{sv}))", &settings);
+    g_assert(g_variant_is_container(settings));
+    GDEBUG("%d plugins", (int) g_variant_n_children(settings));
+    g_assert_cmpint(g_variant_n_children(settings), == ,0);
+    g_variant_unref(settings);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_all_plugin_settings_empty_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetAllPluginSettings",
+        test_get_all_plugin_settings_empty_done);
+}
+
+static
+void
+test_get_all_plugin_settings_empty(
+    void)
+{
+    test_normal(test_get_all_plugin_settings_empty_start);
+}
+
+/*==========================================================================*
+ * get_all_plugin_settings/non_empty
+ *==========================================================================*/
+
+static
+void
+test_get_all_plugin_settings_non_empty_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    const char* name = NULL;
+    GError* error = NULL;
+    GVariant* plugins = NULL;
+    GVariant* plugin = NULL;
+    GVariant* settings = NULL;
+    GVariant* value = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+        result, &error);
+
+    g_assert(var);
+    g_assert(!error);
+    g_variant_get(var, "(@a(sa{sv}))", &plugins);
+    g_assert(g_variant_is_container(plugins));
+    GDEBUG("%d plugin", (int) g_variant_n_children(plugins));
+    g_assert_cmpint(g_variant_n_children(plugins), == ,1);
+    g_assert((plugin = g_variant_get_child_value(plugins, 0)) != NULL);
+    g_variant_get(plugin, "(&s@a{sv})", &name, &settings);
+    g_assert(settings);
+    g_assert_cmpstr(name, == ,TEST_PLUGIN_NAME);
+    g_assert_cmpint(g_variant_n_children(settings), == ,1);
+    g_variant_lookup(settings, TEST_PLUGIN_KEY, "@s", &value);
+    g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_STRING));
+    GDEBUG("%s: %s = %s", name, TEST_PLUGIN_KEY,
+        g_variant_get_string(value, NULL));
+    g_assert_cmpstr(TEST_PLUGIN_DEFAULT_VALUE, == ,
+        g_variant_get_string(value, NULL));
+
+    g_variant_unref(settings);
+    g_variant_unref(plugin);
+    g_variant_unref(plugins);
+    g_variant_unref(value);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_all_plugin_settings_non_empty_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetAllPluginSettings",
+        test_get_all_plugin_settings_non_empty_done);
+}
+
+static
+void
+test_get_all_plugin_settings_non_empty(
+    void)
+{
+    test_normal2(NULL, test_get_all_plugin_settings_non_empty_start);
+}
+
+/*==========================================================================*
+ * get_all_plugin_settings/access_denied
+ *==========================================================================*/
+
+static
+void
+test_get_all_plugin_settings_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call(test, client, "GetAllPluginSettings", test_done_access_denied);
+}
+
+static
+void
+test_get_all_plugin_settings_access_denied(
+    void)
+{
+    test_access_denied(test_get_all_plugin_settings_access_denied_start);
+}
+
+/*==========================================================================*
+ * get_plugin_settings/ok
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_settings_ok_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GError* error = NULL;
+    GVariant* settings = NULL;
+    GVariant* value = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+      result, &error);
+
+    g_assert(!error);
+    g_assert(var);
+    g_variant_get(var, "(@a{sv})", &settings);
+    g_assert(settings);
+    g_assert_cmpint(g_variant_n_children(settings), == ,1);
+    g_variant_lookup(settings, TEST_PLUGIN_KEY, "@s", &value);
+    g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_STRING));
+    GDEBUG("%s = %s", TEST_PLUGIN_KEY, g_variant_get_string(value, NULL));
+    g_assert_cmpstr(TEST_PLUGIN_DEFAULT_VALUE, == ,
+        g_variant_get_string(value, NULL));
+
+    g_variant_unref(settings);
+    g_variant_unref(value);
+    g_variant_unref(var);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_plugin_settings_ok_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_settings(test, client, TEST_PLUGIN_NAME,
+        test_get_plugin_settings_ok_done);
+}
+
+static
+void
+test_get_plugin_settings_ok(
+    void)
+{
+    test_normal2(NULL, test_get_plugin_settings_ok_start);
+}
+
+/*==========================================================================*
+ * get_plugin_settings/access_denied
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_settings_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_settings(test, client, "x", test_done_access_denied);
+}
+
+static
+void
+test_get_plugin_settings_access_denied(
+    void)
+{
+    test_access_denied(test_get_plugin_settings_access_denied_start);
+}
+
+/*==========================================================================*
+ * get_plugin_settings/unknown_plugin
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_settings_unknown_plugin_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_settings(test, client, "x", test_done_unknown_plugin);
+}
+
+static
+void
+test_get_plugin_settings_unknown_plugin(
+    void)
+{
+    test_normal(test_get_plugin_settings_unknown_plugin_start);
+}
+
+/*==========================================================================*
+ * get_plugin_value/default
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_value_default_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    test_get_plugin_value_done(object, result, user_data,
+        TEST_PLUGIN_DEFAULT_VALUE);
+}
+
+static
+void
+test_get_plugin_value_default_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        test_get_plugin_value_default_done);
+}
+
+static
+void
+test_get_plugin_value_default(
+    void)
+{
+    test_normal2(NULL, test_get_plugin_value_default_start);
+}
+
+/*==========================================================================*
+ * get_plugin_value/load
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_value_load_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    test_get_plugin_value_done(object, result, user_data,
+        TEST_PLUGIN_NON_DEFAULT_VALUE);
+}
+
+static
+void
+test_get_plugin_value_load_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        test_get_plugin_value_load_done);
+}
+
+static
+void
+test_get_plugin_value_load(
+    void)
+{
+    /* N.B. Unquoted value is interpreted as a string */
+    test_normal2("[" TEST_PLUGIN_NAME "]\n"
+        TEST_PLUGIN_KEY "=" TEST_PLUGIN_NON_DEFAULT_VALUE "\n",
+        test_get_plugin_value_load_start);
+}
+
+/*==========================================================================*
+ * get_plugin_value/load_error
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_value_load_error_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        test_get_plugin_value_default_done);
+}
+
+static
+void
+test_get_plugin_value_load_error(
+    void)
+{
+    test_normal2("aaaaa", test_get_plugin_value_load_error_start);
+}
+
+/*==========================================================================*
+ * get_plugin_value/access_denied
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_value_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, "x", "y", test_done_access_denied);
+}
+
+static
+void
+test_get_plugin_value_access_denied(
+    void)
+{
+    test_access_denied(test_get_plugin_value_access_denied_start);
+}
+
+/*==========================================================================*
+ * get_plugin_value/unknown_plugin
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_value_unknown_plugin_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, "x", "y",
+        test_done_unknown_plugin);
+}
+
+static
+void
+test_get_plugin_value_unknown_plugin(
+    void)
+{
+    test_normal2(NULL, test_get_plugin_value_unknown_plugin_start);
+}
+
+/*==========================================================================*
+ * get_plugin_value/unknown_key
+ *==========================================================================*/
+
+static
+void
+test_get_plugin_value_unknown_key_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, "y",
+        test_done_unknown_key);
+}
+
+static
+void
+test_get_plugin_value_unknown_key(
+    void)
+{
+    test_normal2(NULL, test_get_plugin_value_unknown_key_start);
+}
+
+/*==========================================================================*
+ * set_plugin_value/ok
+ *==========================================================================*/
+
+#define TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE "foo"
+#define TEST_SET_PLUGIN_VALUE_OK_SIGNAL 0x01
+
+static
+void
+test_set_plugin_value_ok_signal(
+    GDBusConnection* connection,
+    const char* sender,
+    const char* path,
+    const char* iface,
+    const char* name,
+    GVariant* args,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    const char* plugin = NULL;
+    const char* key = NULL;
+    GVariant* value = NULL;
+    GVariant* string = NULL;
+
+    g_variant_get(args, "(&s&s@v)", &plugin, &key, &value);
+    g_assert_cmpstr(plugin, == ,TEST_PLUGIN_NAME);
+    g_assert_cmpstr(key, == ,TEST_PLUGIN_KEY);
+    g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_VARIANT));
+    string = g_variant_get_variant(value);
+    g_assert(g_variant_is_of_type(string, G_VARIANT_TYPE_STRING));
+    GDEBUG("%s=%s", key, g_variant_get_string(string, NULL));
+    g_assert_cmpstr(g_variant_get_string(string, NULL), == ,
+        TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE);
+
+    g_variant_unref(value);
+    g_variant_unref(string);
+
+    /* test_set_plugin_value_ok_done will check this flags */
+    g_assert(!(test->flags & TEST_SET_PLUGIN_VALUE_OK_SIGNAL));
+    test->flags |= TEST_SET_PLUGIN_VALUE_OK_SIGNAL;
+}
+
+static
+void
+test_set_plugin_value_ok_done(
+    GObject* object,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GError* error = NULL;
+    GVariant* var = g_dbus_connection_call_finish(G_DBUS_CONNECTION(object),
+      result, &error);
+    GKeyFile* conf = g_key_file_new();
+    char* str;
+
+    g_assert(!error);
+    g_assert(var);
+    g_variant_unref(var);
+
+    /* We must have received the signal */
+    g_assert((test->flags & TEST_SET_PLUGIN_VALUE_OK_SIGNAL) != 0);
+
+    /* Make sure the new value is saved */
+    g_assert(g_key_file_load_from_file(conf, test->storage_file, 0, NULL));
+    str = g_key_file_get_string(conf, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY, NULL);
+    g_assert_cmpstr(str, == ,"'" TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE "'");
+    g_key_file_unref(conf);
+    g_free(str);
+
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_set_plugin_value_ok_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    g_assert(g_dbus_connection_signal_subscribe(client, NULL,
+        SETTINGS_DBUS_INTERFACE, "PluginValueChanged",
+        SETTINGS_DBUS_PATH, NULL, G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE,
+        test_set_plugin_value_ok_signal, test, NULL));
+    test_call_set_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        g_variant_new_variant(g_variant_new_string(
+        TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE)),
+        test_set_plugin_value_ok_done);
+}
+
+static
+void
+test_set_plugin_value_ok(
+    void)
+{
+    test_normal2(NULL, test_set_plugin_value_ok_start);
+}
+
+/*==========================================================================*
+ * set_plugin_value/access_denied
+ *==========================================================================*/
+
+static
+void
+test_set_plugin_value_access_denied_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_set_plugin_value(test, client, "x", "y",
+        g_variant_new_variant(g_variant_new_boolean(TRUE)),
+        test_done_access_denied);
+}
+
+static
+void
+test_set_plugin_value_access_denied(
+    void)
+{
+    test_access_denied(test_set_plugin_value_access_denied_start);
+}
+
+/*==========================================================================*
+ * set_plugin_value/unknown_plugin
+ *==========================================================================*/
+
+static
+void
+test_set_plugin_value_unknown_plugin_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_set_plugin_value(test, client, "x", "y",
+        g_variant_new_variant(g_variant_new_boolean(TRUE)),
+        test_done_unknown_plugin);
+}
+
+static
+void
+test_set_plugin_value_unknown_plugin(
+    void)
+{
+    test_normal(test_set_plugin_value_unknown_plugin_start);
+}
+
+/*==========================================================================*
+ * set_plugin_value/unknown_key
+ *==========================================================================*/
+
+static
+void
+test_set_plugin_value_unknown_key_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_set_plugin_value(test, client, TEST_PLUGIN_NAME, "y",
+        g_variant_new_variant(g_variant_new_boolean(TRUE)),
+        test_done_unknown_key);
+}
+
+static
+void
+test_set_plugin_value_unknown_key(
+    void)
+{
+    test_normal2(NULL, test_set_plugin_value_unknown_key_start);
+}
+
+/*==========================================================================*
+ * set_plugin_value/invalid_type
+ *==========================================================================*/
+
+static
+void
+test_set_plugin_value_invalid_type_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_set_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        g_variant_new_variant(g_variant_new_boolean(TRUE)), test_done_failed);
+}
+
+static
+void
+test_set_plugin_value_invalid_type(
+    void)
+{
+    test_normal2(NULL, test_set_plugin_value_invalid_type_start);
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+#define TEST_(name) "/plugins/settings/" name
+
+int main(int argc, char* argv[])
+{
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+    g_type_init();
+    G_GNUC_END_IGNORE_DEPRECATIONS;
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func(TEST_("name_lost"), test_name_lost);
+    g_test_add_func(TEST_("defaults/load"), test_defaults_load);
+    g_test_add_func(TEST_("defaults/override"), test_defaults_override);
+    g_test_add_func(TEST_("defaults/no_override"), test_defaults_no_override);
+    g_test_add_func(TEST_("config/load"), test_config_load);
+    g_test_add_func(TEST_("get_all/ok"), test_get_all_ok);
+    g_test_add_func(TEST_("get_all/access_denied"),
+        test_get_all_access_denied);
+    g_test_add_func(TEST_("get_interface_version/ok"),
+        test_get_interface_version_ok);
+    g_test_add_func(TEST_("get_interface_version/access_denied"),
+        test_get_interface_version_access_denied);
+    g_test_add_func(TEST_("get_enabled/ok"), test_get_enabled_ok);
+    g_test_add_func(TEST_("get_enabled/access_denied"),
+        test_get_enabled_access_denied);
+    g_test_add_func(TEST_("set_enabled/ok"), test_set_enabled_ok);
+    g_test_add_func(TEST_("set_enabled/access_denied"),
+        test_set_enabled_access_denied);
+    g_test_add_func(TEST_("get_all2/ok"), test_get_all2_ok);
+    g_test_add_func(TEST_("get_all2/access_denied"),
+        test_get_all2_access_denied);
+    g_test_add_func(TEST_("get_all_plugin_settings/empty"),
+        test_get_all_plugin_settings_empty);
+    g_test_add_func(TEST_("get_all_plugin_settings/non_empty"),
+        test_get_all_plugin_settings_non_empty);
+    g_test_add_func(TEST_("get_all_plugin_settings/access_denied"),
+        test_get_all_plugin_settings_access_denied);
+    g_test_add_func(TEST_("get_plugin_settings/ok"),
+        test_get_plugin_settings_ok);
+    g_test_add_func(TEST_("get_plugin_settings/access_denied"),
+        test_get_plugin_settings_access_denied);
+    g_test_add_func(TEST_("get_plugin_settings/unknown_plugin"),
+        test_get_plugin_settings_unknown_plugin);
+    g_test_add_func(TEST_("get_plugin_value/default"),
+        test_get_plugin_value_default);
+    g_test_add_func(TEST_("get_plugin_value/load"),
+        test_get_plugin_value_load);
+    g_test_add_func(TEST_("get_plugin_value/load_error"),
+        test_get_plugin_value_load_error);
+    g_test_add_func(TEST_("get_plugin_value/access_denied"),
+        test_get_plugin_value_access_denied);
+    g_test_add_func(TEST_("get_plugin_value/unknown_plugin"),
+        test_get_plugin_value_unknown_plugin);
+    g_test_add_func(TEST_("get_plugin_value/unknown_key"),
+        test_get_plugin_value_unknown_key);
+    g_test_add_func(TEST_("set_plugin_value/ok"),
+        test_set_plugin_value_ok);
+    g_test_add_func(TEST_("set_plugin_value/access_denied"),
+        test_set_plugin_value_access_denied);
+    g_test_add_func(TEST_("set_plugin_value/unknown_plugin"),
+        test_set_plugin_value_unknown_plugin);
+    g_test_add_func(TEST_("set_plugin_value/unknown_key"),
+        test_set_plugin_value_unknown_key);
+    g_test_add_func(TEST_("set_plugin_value/invalid_type"),
+        test_set_plugin_value_invalid_type);
+    test_init(&test_opt, argc, argv);
+    return g_test_run();
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */


### PR DESCRIPTION
`NfcConfigurable` interface is utilized to configure plugins. Plugin configuration is stored in `/var/lib/nfcd/settings` file alongside with the global configuration, plugin names being used as section names. Configuration values are converted to strings with `g_variant_print()` and back to GVariants with `g_variant_parse()`.
    
Read-only defaults are loaded from `/etc/nfcd/defaults.conf` file and whatever else is found in `/etc/nfcd/defaults.d` directory. Those can be used for providing device-specific initial values. They must be provided in a form understood by `g_variant_parse()`.