### PR TITLE
Tweaked the configuration saving algorithm

### DIFF
--- a/plugins/settings/settings_plugin.c
+++ b/plugins/settings/settings_plugin.c
@@ -312,120 +312,53 @@ settings_plugin_nfc_always_on(
 }
 
 static
-gboolean
-settings_plugin_update_boolean(
+void
+settings_plugin_save_boolean(
     SettingsPlugin* self,
-    GKeyFile* config,
+    const char* group,
     const char* key,
-    gboolean value)
+    gboolean new_value)
 {
-    const char* group = SETTINGS_GROUP;
+    GKeyFile* config = settings_plugin_load_config(self);
     GError* error = NULL;
-    gboolean default_value = g_key_file_get_boolean(self->defaults, group,
-        key, &error);
-    gboolean have_default = !error;
-    gboolean config_value;
+    gboolean old_value = g_key_file_get_boolean(config, group, key, &error);
+
+    if (error || new_value != old_value) {
+        GVERBOSE("%s/%s = %s", group, key, new_value ? "true" : "false");
+        g_key_file_set_boolean(config, group, key, new_value);
+        settings_plugin_save_config(self, config);
+    }
 
     g_clear_error(&error);
-    config_value = g_key_file_get_boolean(config, group, key, &error);
-    if (error) {
-        g_error_free(error);
-        /* Save it only if it's not the default value */
-        if (!have_default || value != default_value) {
-            g_key_file_set_boolean(config, group, key, value);
-            return TRUE;
-        }
-    } else if (have_default && value == default_value) {
-        /* Remove the default value from the config */
-        if (g_key_file_remove_key(config, group, key, NULL)) {
-            return TRUE;
-        }
-    } else if (config_value != value) {
-        /* Not a default and doesn't match the config - save it */
-        g_key_file_set_boolean(config, group, key, value);
-        return TRUE;
-    }
-    return FALSE;
-}
-
-static
-gboolean
-settings_plugin_update_settings(
-    SettingsPlugin* self,
-    GKeyFile* config)
-{
-    GStrV* plugins = self->order;
-    gboolean save = FALSE;
-
-    if (settings_plugin_update_boolean(self, config, SETTINGS_KEY_ENABLED,
-        self->nfc_enabled)) {
-        save = TRUE;
-    }
-
-    /* Check plugin configs */
-    if (plugins) {
-        while (*plugins) {
-            const char* group = *plugins++;
-            const SettingsPluginConfig* pc = g_hash_table_lookup(self->plugins,
-                group);
-            const char* const* keys = nfc_config_get_keys(pc->config);
-
-            if (keys) {
-                const char* const* ptr = keys;
-
-                while (*ptr) {
-                    const char* key = *ptr++;
-                    GVariant* value = nfc_config_get_value(pc->config, key);
-                    char* str = g_key_file_get_string(config, group, key, NULL);
-                    char* defval = g_key_file_get_value(self->defaults,
-                        group, key, NULL);
-                    char* sval = NULL;
-
-                    if (value) {
-                        sval = g_variant_print(value, FALSE);
-                        g_variant_unref(value);
-                    }
-
-                    if (sval && defval && !strcmp(sval, defval)) {
-                        /* Don't store the default value */
-                        GVERBOSE_("[%s] %s %s => (default)", group,
-                            key, sval);
-                        if (g_key_file_remove_key(config, group, key, NULL)) {
-                            save = TRUE;
-                        }
-                    } else if (g_strcmp0(sval, str)) {
-                        GVERBOSE_("[%s] %s %s => %s", group, key, str, sval);
-                        if (sval) {
-                            g_key_file_set_string(config, group, key, sval);
-                            save = TRUE;
-                        } else if (g_key_file_remove_key(config, group, key,
-                            NULL)) {
-                            save = TRUE;
-                        }
-                    }
-
-                    g_free(defval);
-                    g_free(sval);
-                    g_free(str);
-                }
-            }
-        }
-    }
-
-    return save;
+    g_key_file_unref(config);
 }
 
 static
 void
-settings_plugin_update_config(
-    SettingsPlugin* self)
+settings_plugin_save_value(
+    SettingsPlugin* self,
+    const char* group,
+    const char* key,
+    GVariant* value)
 {
     GKeyFile* config = settings_plugin_load_config(self);
+    char* new_value = value ? g_variant_print(value, FALSE) : NULL;
 
-    if (settings_plugin_update_settings(self, config)) {
+    if (new_value) {
+        char* old_value = g_key_file_get_value(config, group, key, NULL);
+
+        if (g_strcmp0(new_value, old_value)) {
+            GVERBOSE("%s/%s %s => %s", group, key, old_value, new_value);
+            g_key_file_set_value(config, group, key, new_value);
+            settings_plugin_save_config(self, config);
+        }
+        g_free(old_value);
+    } else if (g_key_file_remove_key(config, group, key, NULL)) {
+        GVERBOSE("%s/%s is removed", group, key);
         settings_plugin_save_config(self, config);
     }
 
+    g_free(new_value);
     g_key_file_unref(config);
 }
 
@@ -553,7 +486,6 @@ settings_plugin_set_nfc_enabled(
         GINFO("NFC %s", enabled ? "enabled" : "disabled");
         org_sailfishos_nfc_settings_emit_enabled_changed(self->iface, enabled);
         nfc_manager_set_enabled(self->manager, enabled);
-        settings_plugin_update_config(self);
     }
 }
 
@@ -636,6 +568,8 @@ settings_plugin_dbus_handle_set_enabled(
     if (settings_plugin_access_allowed(self, call,
         SETTINGS_ACTION_SET_ENABLED, SETTINGS_DEFAULT_ACCESS_SET_ENABLED)) {
         settings_plugin_set_nfc_enabled(self, enabled);
+        settings_plugin_save_boolean(self, SETTINGS_GROUP,
+            SETTINGS_KEY_ENABLED, enabled);
         org_sailfishos_nfc_settings_complete_set_enabled(iface, call);
     }
     return TRUE;
@@ -857,9 +791,9 @@ settings_plugin_config_changed(
     SettingsPluginConfig* pc = user_data;
     SettingsPlugin* self = pc->settings;
 
+    settings_plugin_save_value(self, pc->name, key, value);
     org_sailfishos_nfc_settings_emit_plugin_value_changed(self->iface,
         pc->name, key, g_variant_new_variant(value));
-    settings_plugin_update_config(self);
 }
 
 static
@@ -947,7 +881,13 @@ settings_plugin_started(
     GKeyFile* config = settings_plugin_load_config(self);
     char** names;
 
+    /* Special case, one-time dbus_neard migration */
+    const char* migrate_plugin_name = "dbus_neard";
+    const char* migrate_plugin_key = "BluetoothStaticHandover";
+    gboolean save_config = FALSE;
+
     /* All functional plugins have been successfully started */
+    GVERBOSE("Initializing");
     while (*ptr) {
         NfcPlugin* p = *ptr++;
 
@@ -980,10 +920,10 @@ settings_plugin_started(
         if (keys) {
             while (*keys) {
                 const char* key = *keys++;
-                char* str = g_key_file_get_string(config, name, key, NULL);
+                char* str = g_key_file_get_value(config, name, key, NULL);
 
                 if (!str) {
-                    str = g_key_file_get_string(self->defaults, name, key,
+                    str = g_key_file_get_value(self->defaults, name, key,
                         NULL);
                 }
                 if (str) {
@@ -998,6 +938,18 @@ settings_plugin_started(
                     nfc_config_set_value(pc->config, key, var);
                     g_variant_unref(var);
                     g_free(str);
+                } else if (!save_config &&
+                    !strcmp(name, migrate_plugin_name) &&
+                    !strcmp(key, migrate_plugin_key)) {
+                    GVariant* value = nfc_config_get_value(pc->config, key);
+
+                    if (value) {
+                        save_config = TRUE;
+                        str = g_variant_print(value, FALSE);
+                        g_key_file_set_value(config, name, key, str);
+                        g_variant_unref(value);
+                        g_free(str);
+                    }
                 }
             }
         }
@@ -1016,8 +968,7 @@ settings_plugin_started(
         nfc_manager_request_power(self->manager, TRUE);
     }
 
-    /* Check the config (mostly for dbus_neard migration) */
-    if (settings_plugin_update_settings(self, config)) {
+    if (save_config) {
         settings_plugin_save_config(self, config);
     }
 

--- a/unit/plugins_settings/test_plugins_settings.c
+++ b/unit/plugins_settings/test_plugins_settings.c
@@ -57,6 +57,7 @@ static DA_ACCESS test_access = DA_ACCESS_ALLOW;
 
 #define TMP_DIR_TEMPLATE                 "test_XXXXXX"
 #define TEST_PLUGIN_NAME                 "test"
+#define TEST_DBUS_NEARD_PLUGIN_NAME      "dbus_neard"
 
 #define SETTINGS_CONFIG_DEFAULTS_FILE    "defaults.conf"
 #define SETTINGS_CONFIG_DEFAULTS_DIR     "defaults.d"
@@ -116,6 +117,15 @@ static GUtilIdlePool* test_pool;
 static const char* dbus_sender = ":1.0";
 
 static NfcPlugin* test_plugin_create(void);
+static NfcPlugin* test_dbus_neard_plugin_create(void);
+static const NfcPluginDesc NFC_PLUGIN_DESC(test) = {
+    TEST_PLUGIN_NAME, "Test", NFC_CORE_VERSION,
+    test_plugin_create, NULL, 0
+};
+static const NfcPluginDesc NFC_PLUGIN_DESC(dbus_neard) = {
+    TEST_DBUS_NEARD_PLUGIN_NAME, "Dummy neard D-Bus plugin", NFC_CORE_VERSION,
+    test_dbus_neard_plugin_create, NULL, 0
+};
 
 static
 void
@@ -159,23 +169,35 @@ test_data_init_with_plugins(
 
 static
 void
+test_data_init4(
+    TestData* test,
+    const char* config,
+    TestFunc prestart)
+{
+    static const NfcPluginDesc* const test_plugins4[] = {
+        &NFC_PLUGIN_DESC(settings),
+        &NFC_PLUGIN_DESC(test),
+        &NFC_PLUGIN_DESC(dbus_neard),
+        NULL
+    };
+
+    test_data_init_with_plugins(test, config, prestart, test_plugins4);
+}
+
+static
+void
 test_data_init3(
     TestData* test,
     const char* config,
     TestFunc prestart)
 {
-    static const NfcPluginDesc NFC_PLUGIN_DESC(test) = {
-        TEST_PLUGIN_NAME, "Test", NFC_CORE_VERSION,
-        test_plugin_create, NULL, 0
-    };
-
-    static const NfcPluginDesc* const test_plugins2[] = {
+    static const NfcPluginDesc* const test_plugins3[] = {
         &NFC_PLUGIN_DESC(settings),
         &NFC_PLUGIN_DESC(test),
         NULL
     };
 
-    test_data_init_with_plugins(test, config, prestart, test_plugins2);
+    test_data_init_with_plugins(test, config, prestart, test_plugins3);
 }
 
 static
@@ -360,40 +382,81 @@ test_done_access_denied(
 
 static
 void
-test_get_plugin_value_check(
+test_get_plugin_string_value_check(
     GDBusConnection* client,
     GAsyncResult* result,
     TestData* test,
     const char* expected_value)
 {
     GError* error = NULL;
+    GVariant* svalue = NULL;
     GVariant* value = NULL;
-    GVariant* string = NULL;
     GVariant* var = g_dbus_connection_call_finish(client, result, &error);
 
     g_assert(!error);
     g_assert(var);
     g_variant_get(var, "(@v)", &value);
     g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_VARIANT));
-    string = g_variant_get_variant(value);
-    g_assert(g_variant_is_of_type(string, G_VARIANT_TYPE_STRING));
-    GDEBUG("%s", g_variant_get_string(string, NULL));
-    g_assert_cmpstr(g_variant_get_string(string, NULL), == ,expected_value);
+    svalue = g_variant_get_variant(value);
+    g_assert(g_variant_is_of_type(svalue, G_VARIANT_TYPE_STRING));
+    GDEBUG("%s", g_variant_get_string(svalue, NULL));
+    g_assert_cmpstr(g_variant_get_string(svalue, NULL), == ,expected_value);
 
+    g_variant_unref(svalue);
     g_variant_unref(value);
-    g_variant_unref(string);
     g_variant_unref(var);
 }
 
 static
 void
-test_get_plugin_value_done(
+test_get_plugin_boolean_value_check(
+    GDBusConnection* client,
+    GAsyncResult* result,
+    TestData* test,
+    gboolean expected_value)
+{
+    GError* error = NULL;
+    GVariant* bvalue = NULL;
+    GVariant* value = NULL;
+    GVariant* var = g_dbus_connection_call_finish(client, result, &error);
+
+    g_assert(!error);
+    g_assert(var);
+    g_variant_get(var, "(@v)", &value);
+    g_assert(g_variant_is_of_type(value, G_VARIANT_TYPE_VARIANT));
+    bvalue = g_variant_get_variant(value);
+    g_assert(g_variant_is_of_type(bvalue, G_VARIANT_TYPE_BOOLEAN));
+    GDEBUG("%s", g_variant_get_boolean(bvalue) ? "true" : "false");
+    g_assert_cmpint(g_variant_get_boolean(bvalue), == ,expected_value);
+
+    g_variant_unref(bvalue);
+    g_variant_unref(value);
+    g_variant_unref(var);
+}
+
+static
+void
+test_get_plugin_string_value_done(
     GObject* client,
     GAsyncResult* result,
     TestData* test,
-    const char* val)
+    const char* expected_value)
 {
-    test_get_plugin_value_check(G_DBUS_CONNECTION(client), result, test, val);
+    test_get_plugin_string_value_check(G_DBUS_CONNECTION(client), result,
+        test, expected_value);
+    test_quit_later(test->loop);
+}
+
+static
+void
+test_get_plugin_boolean_value_done(
+    GObject* client,
+    GAsyncResult* result,
+    TestData* test,
+    gboolean expected_value)
+{
+    test_get_plugin_boolean_value_check(G_DBUS_CONNECTION(client), result,
+        test, expected_value);
     test_quit_later(test->loop);
 }
 
@@ -506,6 +569,36 @@ test_done_failed(
 
 static
 void
+test_check_config_value(
+    GKeyFile* config,
+    const char* group,
+    const char* key,
+    const char* expected_value)
+{
+    char* value;
+
+    value = g_key_file_get_value(config, group, key, NULL);
+    g_assert_cmpstr(value, == ,expected_value);
+    g_free(value);
+}
+
+static
+void
+test_check_config_file_value(
+    TestData* test,
+    const char* group,
+    const char* key,
+    const char* expected_value)
+{
+    GKeyFile* config = g_key_file_new();
+
+    g_assert(g_key_file_load_from_file(config, test->storage_file, 0, NULL));
+    test_check_config_value(config, group, key, expected_value);
+    g_key_file_unref(config);
+}
+
+static
+void
 test_normal_run(
     void (*init)(TestData* test, const char* config),
     const char* config,
@@ -557,6 +650,24 @@ test_normal3(
     test_dbus_free(dbus);
 }
 
+static
+void
+test_normal4(
+    const char* config,
+    TestFunc prestart,
+    TestDBusStartFunc start)
+{
+    TestData test;
+    TestDBus* dbus;
+
+    test_allow_calls();
+    test_data_init4(&test, config, prestart);
+    dbus = test_dbus_new2(test_start, start, &test);
+    test_run(&test_opt, test.loop);
+    test_data_cleanup(&test);
+    test_dbus_free(dbus);
+}
+
 /*==========================================================================*
  * Test plugin
  *==========================================================================*/
@@ -564,7 +675,6 @@ test_normal3(
 typedef NfcPluginClass TestPluginClass;
 typedef struct test_plugin {
     NfcPlugin plugin;
-    NfcManager* manager;
     char* value;
     char* value2;
 } TestPlugin;
@@ -576,17 +686,15 @@ typedef struct test_plugin {
 static void test_plugin_config_init(NfcConfigurableInterface* iface);
 G_DEFINE_TYPE_WITH_CODE(TestPlugin, test_plugin, NFC_TYPE_PLUGIN,
 G_IMPLEMENT_INTERFACE(NFC_TYPE_CONFIGURABLE, test_plugin_config_init))
-#define TEST_TYPE_PLUGIN (test_plugin_get_type())
+#define TEST_TYPE_PLUGIN test_plugin_get_type()
 #define TEST_PLUGIN(obj) (G_TYPE_CHECK_INSTANCE_CAST(obj, \
         TEST_TYPE_PLUGIN, TestPlugin))
-#define PARENT_CLASS() G_TYPE_CHECK_CLASS_CAST(test_plugin_parent_class, \
-        NFC_TYPE_PLUGIN, NfcPluginClass)
 #define TEST_CONFIG_VALUE_CHANGED_NAME "test-plugin-config-value-changed"
-enum neard_plugin_signal {
+enum test_plugin_signal {
      TEST_CONFIG_VALUE_CHANGED,
-     TEST_PLUGIN_SIGNAL_COUNT
+     TEST_PLUGIN_SIGNALS
 };
-static guint test_plugin_signals[TEST_PLUGIN_SIGNAL_COUNT] = { 0 };
+static guint test_plugin_signals[TEST_PLUGIN_SIGNALS] = { 0 };
 
 static
 NfcPlugin*
@@ -602,23 +710,7 @@ test_plugin_start(
     NfcPlugin* plugin,
     NfcManager* manager)
 {
-    TestPlugin* self = TEST_PLUGIN(plugin);
-
-    g_assert(!self->manager);
-    self->manager = manager;
     return TRUE;
-}
-
-static
-void
-test_plugin_stop(
-    NfcPlugin* plugin)
-{
-    TestPlugin* self = TEST_PLUGIN(plugin);
-
-    g_assert(self->manager);
-    self->manager = NULL;
-    PARENT_CLASS()->stop(plugin);
 }
 
 static
@@ -648,7 +740,6 @@ test_plugin_class_init(
 {
     G_OBJECT_CLASS(klass)->finalize = test_plugin_finalize;
     klass->start = test_plugin_start;
-    klass->stop = test_plugin_stop;
     test_plugin_signals[TEST_CONFIG_VALUE_CHANGED] =
         g_signal_new(TEST_CONFIG_VALUE_CHANGED_NAME,
             G_OBJECT_CLASS_TYPE(klass), G_SIGNAL_RUN_FIRST |
@@ -760,6 +851,145 @@ test_plugin_config_init(
     iface->get_value = test_plugin_config_get_value;
     iface->set_value = test_plugin_config_set_value;
     iface->add_change_handler = test_plugin_config_add_change_handler;
+}
+
+/*==========================================================================*
+ * Dummy dbus_neard plugin (to test migration)
+ *==========================================================================*/
+
+typedef NfcPluginClass TestDBusNeardPluginClass;
+typedef struct test_dbus_neard_plugin {
+    NfcPlugin plugin;
+    gboolean value;
+} TestDBusNeardPlugin;
+
+#define DBUS_NEARD_PLUGIN_KEY "BluetoothStaticHandover"
+#define DBUS_NEARD_PLUGIN_DEFAULT_VALUE FALSE
+
+static void test_dbus_neard_plugin_config_init(NfcConfigurableInterface* intf);
+G_DEFINE_TYPE_WITH_CODE(TestDBusNeardPlugin, test_dbus_neard_plugin,
+NFC_TYPE_PLUGIN, G_IMPLEMENT_INTERFACE(NFC_TYPE_CONFIGURABLE,
+test_dbus_neard_plugin_config_init))
+#define TEST_TYPE_DBUS_NEARD_PLUGIN (test_dbus_neard_plugin_get_type())
+#define TEST_DBUS_NEARD_PLUGIN(obj) (G_TYPE_CHECK_INSTANCE_CAST(obj, \
+        TEST_TYPE_DBUS_NEARD_PLUGIN, TestDBusNeardPlugin))
+#define TEST_DBUS_NEARD_CONFIG_VALUE_CHANGED_NAME \
+        "test-dbus_neard-plugin-config-value-changed"
+enum test_dbus_neard_plugin_signal {
+     TEST_DBUS_NEARD_CONFIG_VALUE_CHANGED,
+     TEST_DBUS_NEARD_SIGNALS
+};
+static guint test_dbus_neard_plugin_signals[TEST_DBUS_NEARD_SIGNALS] = { 0 };
+
+static
+NfcPlugin*
+test_dbus_neard_plugin_create(
+    void)
+{
+    return g_object_new(TEST_TYPE_DBUS_NEARD_PLUGIN, NULL);
+}
+
+static
+void
+test_dbus_neard_plugin_init(
+    TestDBusNeardPlugin* self)
+{
+    self->value = DBUS_NEARD_PLUGIN_DEFAULT_VALUE;
+}
+
+static
+void
+test_dbus_neard_plugin_class_init(
+    NfcPluginClass* klass)
+{
+    klass->start = test_plugin_start; /* Reusable */
+    test_dbus_neard_plugin_signals[TEST_DBUS_NEARD_CONFIG_VALUE_CHANGED] =
+        g_signal_new(TEST_DBUS_NEARD_CONFIG_VALUE_CHANGED_NAME,
+            G_OBJECT_CLASS_TYPE(klass), G_SIGNAL_RUN_FIRST |
+            G_SIGNAL_DETAILED, 0, NULL, NULL, NULL,
+            G_TYPE_NONE, 2, G_TYPE_STRING, G_TYPE_VARIANT);
+}
+
+static
+const char* const*
+test_dbus_neard_config_get_keys(
+    NfcConfigurable* config)
+{
+    static const char* const test_dbus_neard_plugin_keys[] = {
+        DBUS_NEARD_PLUGIN_KEY, NULL
+    };
+
+    return test_dbus_neard_plugin_keys;
+}
+
+static
+GVariant*
+test_dbus_neard_config_get_value(
+    NfcConfigurable* config,
+    const char* key)
+{
+    /* OK to return a floating reference */
+    if (!g_strcmp0(key, DBUS_NEARD_PLUGIN_KEY)) {
+        return g_variant_new_boolean(TEST_DBUS_NEARD_PLUGIN(config)->value);
+    }
+    return NULL;
+}
+
+static
+gboolean
+test_dbus_neard_config_set_value(
+    NfcConfigurable* config,
+    const char* key,
+    GVariant* value)
+{
+    gboolean ok = FALSE;
+
+    if (!g_strcmp0(key, DBUS_NEARD_PLUGIN_KEY)) {
+        TestDBusNeardPlugin* self = TEST_DBUS_NEARD_PLUGIN(config);
+        gboolean newval = DBUS_NEARD_PLUGIN_DEFAULT_VALUE;
+
+        if (!value) {
+            ok = TRUE;
+        } else if (g_variant_is_of_type(value, G_VARIANT_TYPE_BOOLEAN)) {
+            newval = g_variant_get_boolean(value);
+            ok = TRUE;
+        }
+
+        if (ok && self->value != newval) {
+            GDEBUG("%s: %s => %s", key, self->value ? "true" : "false",
+                newval ? "true" : "false");
+            self->value = newval;
+            g_signal_emit(self, test_dbus_neard_plugin_signals
+                [TEST_DBUS_NEARD_CONFIG_VALUE_CHANGED],
+                g_quark_from_string(key), key, value);
+        }
+    }
+    return ok;
+}
+
+static
+gulong
+test_dbus_neard_config_add_change_handler(
+    NfcConfigurable* config,
+    const char* key,
+    NfcConfigChangeFunc func,
+    void* user_data)
+{
+    return g_signal_connect_closure_by_id(TEST_DBUS_NEARD_PLUGIN(config),
+        test_dbus_neard_plugin_signals[TEST_DBUS_NEARD_CONFIG_VALUE_CHANGED],
+        key ? g_quark_from_string(key) : 0,
+        g_cclosure_new(G_CALLBACK(func), user_data, NULL), FALSE);
+}
+
+static
+void
+test_dbus_neard_plugin_config_init(
+    NfcConfigurableInterface* iface)
+{
+    iface->get_keys = test_dbus_neard_config_get_keys;
+    iface->get_value = test_dbus_neard_config_get_value;
+    iface->set_value = test_dbus_neard_config_set_value;
+    iface->add_change_handler = test_dbus_neard_config_add_change_handler;
 }
 
 /*==========================================================================*
@@ -966,7 +1196,7 @@ test_defaults_load_done(
     GAsyncResult* result,
     gpointer user_data)
 {
-    test_get_plugin_value_done(object, result, user_data, "foo");
+    test_get_plugin_string_value_done(object, result, user_data, "foo");
 }
 
 static
@@ -1064,7 +1294,7 @@ test_defaults_override_done(
 
     /* Since all values are default, there was need to save the settings */
     g_assert(!g_file_test(test->storage_file, G_FILE_TEST_EXISTS));
-    test_get_plugin_value_done(object, result, test, "bar");
+    test_get_plugin_string_value_done(object, result, test, "bar");
 }
 
 static
@@ -1141,7 +1371,7 @@ test_defaults_no_override_done(
 
     /* Since all values are default, there was need to save the settings */
     g_assert(!g_file_test(test->storage_file, G_FILE_TEST_EXISTS));
-    test_get_plugin_value_done(object, result, test, "foo");
+    test_get_plugin_string_value_done(object, result, test, "foo");
 }
 
 static
@@ -1215,59 +1445,10 @@ void
 test_config_load_done(
     GObject* client,
     GAsyncResult* result,
-    gpointer user_data)
+    gpointer test)
 {
-    TestData* test = user_data;
-    GKeyFile* config = g_key_file_new();
-
-    test_call_ok_done(client, result, test);
-
-    /*
-     * The config file is there but the value has been removed because
-     * it now matches the default.
-     */
-    g_assert(g_key_file_load_from_file(config, test->storage_file, 0, NULL));
-    g_assert(!g_key_file_get_value(config, TEST_PLUGIN_NAME,
-        TEST_PLUGIN_KEY, NULL));
-    g_assert(!g_key_file_get_value(config, SETTINGS_GROUP,
-        SETTINGS_KEY_ENABLED, NULL));
-    g_key_file_unref(config);
-}
-
-static
-void
-test_config_load_enabled(
-    GObject* object,
-    GAsyncResult* result,
-    gpointer user_data)
-{
-    TestData* test = user_data;
-    GDBusConnection* client = G_DBUS_CONNECTION(object);
-
-    test_call_ok_check(client, result);
-    g_assert(test->manager->enabled);
-
-    /* Set the plugin value matching the default loaded from the file */
-    test_call_set_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
-        g_variant_new_variant(g_variant_new_string("bar")),
-        test_config_load_done);
-}
-
-static
-void
-test_config_load_check(
-    GObject* object,
-    GAsyncResult* result,
-    gpointer user_data)
-{
-    TestData* test = user_data;
-    GDBusConnection* client = G_DBUS_CONNECTION(object);
-
     /* Value is taken from the config */
-    test_get_plugin_value_check(client, result, user_data, "foo");
-
-    /* Set Enabled value that matches the default loaded from the file */
-    test_call_set_enabled(test, client, TRUE, test_config_load_enabled);
+    test_get_plugin_string_value_done(client, result, (TestData*) test, "foo");
 }
 
 static
@@ -1281,7 +1462,7 @@ test_config_load_start(
 
     g_assert(!test->manager->enabled);
     test_call_get_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
-        test_config_load_check);
+        test_config_load_done);
 }
 
 static
@@ -1360,6 +1541,99 @@ test_config_save(
     void)
 {
     test_normal2(NULL, test_config_save_start);
+}
+
+/*==========================================================================*
+ * migrate
+ *==========================================================================*/
+
+static
+void
+test_migrate_done(
+    GObject* client,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GKeyFile* config = g_key_file_new();
+    GError* error = NULL;
+
+    test_get_plugin_boolean_value_done(client, result, test,
+        DBUS_NEARD_PLUGIN_DEFAULT_VALUE);
+
+    /* Verify that the "BluetoothStaticHandover" value has been migrated */
+    g_assert(g_key_file_load_from_file(config, test->storage_file, 0, NULL));
+    g_assert_cmpint(g_key_file_get_boolean(config, TEST_DBUS_NEARD_PLUGIN_NAME,
+        DBUS_NEARD_PLUGIN_KEY, &error), == ,DBUS_NEARD_PLUGIN_DEFAULT_VALUE);
+    g_assert(!error);
+
+    g_key_file_unref(config);
+}
+
+static
+void
+test_migrate_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, TEST_DBUS_NEARD_PLUGIN_NAME,
+        DBUS_NEARD_PLUGIN_KEY, test_migrate_done);
+}
+
+static
+void
+test_migrate(
+    void)
+{
+    test_normal4(NULL, NULL, test_migrate_start);
+}
+
+/*==========================================================================*
+ * no_migrate
+ *==========================================================================*/
+
+static
+void
+test_no_migrate_done(
+    GObject* client,
+    GAsyncResult* result,
+    gpointer user_data)
+{
+    TestData* test = user_data;
+    GKeyFile* config = g_key_file_new();
+    GError* error = NULL;
+
+    test_get_plugin_boolean_value_done(client, result, test,
+        !DBUS_NEARD_PLUGIN_DEFAULT_VALUE);
+
+    /* Verify that the "BluetoothStaticHandover" value stays unchanged */
+    g_assert(g_key_file_load_from_file(config, test->storage_file, 0, NULL));
+    g_assert_cmpint(g_key_file_get_boolean(config, TEST_DBUS_NEARD_PLUGIN_NAME,
+        DBUS_NEARD_PLUGIN_KEY, &error), == ,!DBUS_NEARD_PLUGIN_DEFAULT_VALUE);
+    g_assert(!error);
+
+    g_key_file_unref(config);
+}
+
+static
+void
+test_no_migrate_start(
+    GDBusConnection* client,
+    GDBusConnection* server,
+    void* test)
+{
+    test_call_get_plugin_value(test, client, TEST_DBUS_NEARD_PLUGIN_NAME,
+        DBUS_NEARD_PLUGIN_KEY, test_no_migrate_done);
+}
+
+static
+void
+test_no_migrate(
+    void)
+{
+    test_normal4("[" TEST_DBUS_NEARD_PLUGIN_NAME "]\n"
+        DBUS_NEARD_PLUGIN_KEY "=true\n", NULL, test_no_migrate_start);
 }
 
 /*==========================================================================*
@@ -1979,7 +2253,7 @@ test_get_plugin_value_default_done(
     GAsyncResult* result,
     gpointer user_data)
 {
-    test_get_plugin_value_done(object, result, user_data,
+    test_get_plugin_string_value_done(object, result, user_data,
         TEST_PLUGIN_DEFAULT_VALUE);
 }
 
@@ -2013,7 +2287,7 @@ test_get_plugin_value_load_done(
     GAsyncResult* result,
     gpointer user_data)
 {
-    test_get_plugin_value_done(object, result, user_data,
+    test_get_plugin_string_value_done(object, result, user_data,
         TEST_PLUGIN_NON_DEFAULT_VALUE);
 }
 
@@ -2210,14 +2484,8 @@ void
 test_set_plugin_value_ok_check_config(
     TestData* test)
 {
-    GKeyFile* conf = g_key_file_new();
-    char* str;
-
-    g_assert(g_key_file_load_from_file(conf, test->storage_file, 0, NULL));
-    str = g_key_file_get_string(conf, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY, NULL);
-    g_assert_cmpstr(str, == ,"'" TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE "'");
-    g_key_file_unref(conf);
-    g_free(str);
+    test_check_config_file_value(test, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        "'" TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE "'");
 }
 
 static
@@ -2243,8 +2511,6 @@ test_set_plugin_value_ok_repeat(
 {
     GDBusConnection* client = G_DBUS_CONNECTION(object);
     TestData* test = user_data;
-    GKeyFile* conf = g_key_file_new();
-    char* str;
 
     test_call_ok_check(client, result);
 
@@ -2252,11 +2518,8 @@ test_set_plugin_value_ok_repeat(
     g_assert_cmpint(test->flags, == ,TEST_PLUGIN_VALUE_CHANGED_SIGNAL_FLAG);
 
     /* Make sure the new value is saved */
-    g_assert(g_key_file_load_from_file(conf, test->storage_file, 0, NULL));
-    str = g_key_file_get_string(conf, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY, NULL);
-    g_assert_cmpstr(str, == ,"'" TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE "'");
-    g_key_file_unref(conf);
-    g_free(str);
+    test_check_config_file_value(test, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
+        "'" TEST_SET_PLUGIN_VALUE_OK_NEW_VALUE "'");
 
     /* There won't be any signals if we're settings the save value again */
     test_call_set_plugin_value(test, client, TEST_PLUGIN_NAME, TEST_PLUGIN_KEY,
@@ -2403,6 +2666,8 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("defaults/no_override"), test_defaults_no_override);
     g_test_add_func(TEST_("config/load"), test_config_load);
     g_test_add_func(TEST_("config/save"), test_config_save);
+    g_test_add_func(TEST_("migrate"), test_migrate);
+    g_test_add_func(TEST_("no_migrate"), test_no_migrate);
     g_test_add_func(TEST_("get_all/ok"), test_get_all_ok);
     g_test_add_func(TEST_("get_all/access_denied"),
         test_get_all_access_denied);


### PR DESCRIPTION
Only the values modified over D-Bus are now saved to the config file. That way, whenever external defaults change, they affect the runtime behavior if and only if the value has never been modified (presumably by the user).