### PR TITLE
Add respond_bytes method to NfcInitiator

### DIFF
--- a/core/include/nfc_initiator_impl.h
+++ b/core/include/nfc_initiator_impl.h
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2020-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2020-2021 Jolla Ltd.
- * Copyright (C) 2020-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -57,6 +57,18 @@ typedef struct nfc_initiator_class {
     /* These base implementation emits signal, must always be called. */
     void (*gone)(NfcInitiator* initiator);
 
+    /*
+     * Since 1.1.15
+     *
+     * NfcInitiatorClass implementation may use this callback to avoid
+     * copying the data and allocating unnecessary GBytes objects. The
+     * base class calls respond() with the data contained in this GBytes.
+     *
+     * N.B. Even if the respond_bytes() is handled, respond() can still
+     * be called, the implementation must be prepared to handle both.
+     */
+    gboolean (*respond_bytes)(NfcInitiator* initiator, GBytes* data);
+
     /* Padding for future expansion */
     void (*_reserved1)(void);
     void (*_reserved2)(void);
@@ -67,7 +79,6 @@ typedef struct nfc_initiator_class {
     void (*_reserved7)(void);
     void (*_reserved8)(void);
     void (*_reserved9)(void);
-    void (*_reserved10)(void);
 } NfcInitiatorClass;
 
 #define NFC_INITIATOR_CLASS(klass) G_TYPE_CHECK_CLASS_CAST((klass), \

--- a/core/src/nfc_initiator_p.h
+++ b/core/src/nfc_initiator_p.h
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2020-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -114,6 +114,14 @@ nfc_transmission_respond(
     NfcTransmission* transmission,
     const void* data,
     guint len,
+    NfcTransmissionDoneFunc done,
+    void* user_data)
+    NFCD_INTERNAL;
+
+gboolean
+nfc_transmission_respond_bytes(
+    NfcTransmission* transmission,
+    GBytes* data,
     NfcTransmissionDoneFunc done,
     void* user_data)
     NFCD_INTERNAL;

--- a/core/src/nfc_llc_io_target.c
+++ b/core/src/nfc_llc_io_target.c
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2020-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -149,14 +149,12 @@ static
 gboolean
 nfc_llc_io_target_send(
     NfcLlcIo* io,
-    GBytes* send)
+    GBytes* data)
 {
     NfcLlcIoTarget* self = THIS(io);
-    gsize size;
-    gconstpointer data = g_bytes_get_data(send, &size);
 
     io->can_send = FALSE;
-    if (nfc_transmission_respond(self->transmission, data, (guint)size,
+    if (nfc_transmission_respond_bytes(self->transmission, data,
         nfc_llc_io_target_response_sent, self)) {
         return TRUE;
     } else {


### PR DESCRIPTION
It allows to avoid allocating unnecessary GBytes objects and reduce data copying in Listen mode. The default implementation is backward compatible with the existing plugins.