### PR TITLE
Power up the adapter when enabled

### DIFF
--- a/plugins/settings/settings_plugin.c
+++ b/plugins/settings/settings_plugin.c
@@ -486,6 +486,7 @@ settings_plugin_set_nfc_enabled(
         GINFO("NFC %s", enabled ? "enabled" : "disabled");
         org_sailfishos_nfc_settings_emit_enabled_changed(self->iface, enabled);
         nfc_manager_set_enabled(self->manager, enabled);
+        nfc_manager_request_power(self->manager, enabled);
     }
 }
 


### PR DESCRIPTION
NFCD does not power up the adapter on devices I have.  This one line change calls powerup when the adapter is enabled.