### PR TITLE
Handle the case when target disappears instead of reactivating

### DIFF
--- a/core/src/nfc_target.c
+++ b/core/src/nfc_target.c
@@ -3,32 +3,35 @@
  * Copyright (C) 2018-2022 Jolla Ltd.
  * Copyright (C) 2020 Open Mobile Platform LLC.
  *
- * You may use this file under the terms of BSD license as follows:
+ * You may use this file under the terms of the BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  *
- *   1. Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived
- *      from this software without specific prior written permission.
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer
+ *     in the documentation and/or other materials provided with the
+ *     distribution.
+ *  3. Neither the names of the copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) ARISING
+ * IN ANY WAY OUT OF THE USE OR INABILITY TO USE THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
  */
 
 #include "nfc_target_p.h"
@@ -704,11 +707,19 @@ nfc_target_submit_request(
         nfc_target_set_sequence(self, req->seq);
     }
     if (rt->submit(req)) {
-        const guint ms = rt->timeout_ms(req);
+        /*
+         * If the target goes away during submission of the request, the
+         * request is already completed and freed by now (but we still
+         * return TRUE to indicate that it has been submitted).
+         */
+        if (priv->req_active == req) {
+            const guint ms = rt->timeout_ms(req);
 
-        if (ms) {
-            GASSERT(!req->timeout);
-            req->timeout = g_timeout_add(ms, nfc_target_request_timeout, req);
+            if (ms) {
+                GASSERT(!req->timeout);
+                req->timeout = g_timeout_add(ms,
+                    nfc_target_request_timeout, req);
+            }
         }
         return TRUE;
     } else {


### PR DESCRIPTION
Avoid this use-after-free scenario:
```
Invalid read of size 8
  at 0x1115AD: nfc_target_reactivate_request_timeout_ms (nfc_target.c:325)
  by 0x112002: nfc_target_submit_request (nfc_target.c:707)
  by 0x1120D7: nfc_target_submit_next_request (nfc_target.c:732)
  by 0x11282C: nfc_target_reactivate (nfc_target.c:1001)
  ...
Address 0x4ec9648 is 24 bytes inside a block of size 64 free'd
  at 0x484B27F: free
  by 0x11174E: nfc_target_reactivate_request_free (nfc_target.c:395)
  by 0x111C59: nfc_target_free_request (nfc_target.c:603)
  by 0x111C95: nfc_target_fail_request (nfc_target.c:614)
  by 0x11223D: nfc_target_fail_requests (nfc_target.c:783)
  by 0x112BDD: nfc_target_gone_handler (nfc_target.c:1152)
  by 0x112B64: nfc_target_gone (nfc_target.c:1114)
  ...
  by 0x111513: nfc_target_reactivate_request_submit (nfc_target.c:302)
  by 0x111FED: nfc_target_submit_request (nfc_target.c:706)
  by 0x1120D7: nfc_target_submit_next_request (nfc_target.c:732)
  by 0x11282C: nfc_target_reactivate (nfc_target.c:1001)
  ...
Block was alloc'd at
  at 0x4848899: malloc
  by 0x11177B: nfc_target_reactivate_request_new (nfc_target.c:420)
  by 0x112805: nfc_target_reactivate (nfc_target.c:997)
  ...
```