### PR TITLE
[nfcd] Remove reading old nemo/locale.conf. JB#55730

### DIFF
--- a/src/nfcd.service
+++ b/src/nfcd.service
@@ -8,7 +8,6 @@ Type=dbus
 BusName=org.sailfishos.nfc.daemon
 User=nfc
 EnvironmentFile=-/var/lib/environment/nfcd/*.conf
-EnvironmentFile=-/var/lib/environment/nemo/locale.conf
 ExecStart=/usr/sbin/nfcd -o syslog $NFCD_ARGS
 Restart=always
 RestartSec=3


### PR DESCRIPTION
Was added with commit faa8971d, apparently for deciding what languages to prioritize if tag has text content for multiple languages. Suppose that's these days libnfcdef's usage of ndef_system_language().

The nemo user hasn't existed for newly flashed devices in ages and the system locale should be already available via /etc/locale.conf. Think it should be safe to just remove this.