### PR TITLE
src/Makefile: fix parallel build race in gdbus code generation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -172,6 +172,9 @@ nfc_plugins_debug_lib:
 nfc_plugins_release_lib:
 	$(MAKE) -C $(NFC_PLUGINS_DIR) release
 
+# Serialize plugin builds to avoid gdbus-codegen race on shared build/gen/ dir
+nfc_plugins_release_lib: | nfc_plugins_debug_lib
+
 $(DEBUG_BUILD_DIR):
 	mkdir -p $@
 


### PR DESCRIPTION
When building with make -jN, the debug and release builds of the plugins sub-make can run simultaneously. Both invoke gdbus-codegen to generate code in the same build/gen/ directory, causing a race condition where one gdbus-codegen invocation truncates and rewrites the \`.h\` file while the other build is compiling the \`.c\` that includes it.

This results in errors like "unknown type name 'GDBusArgInfo'" because the compiler reads a partially-written (or empty) generated header file.

Fix by making the release plugins build depend on the debug plugins build via an order-only prerequisite. This ensures gdbus-codegen runs to completion during the debug build before the release build starts, while not affecting the build order in other ways.